### PR TITLE
[RDE 47] results summary frontend

### DIFF
--- a/frontend/app/components/quiz/results/AttemptReview.tsx
+++ b/frontend/app/components/quiz/results/AttemptReview.tsx
@@ -22,7 +22,7 @@ export default function AttemptReview({
   onBack,
 }: AttemptReviewProps) {
   return (
-    <div className="flex min-h-full w-full max-w-[390px] flex-col bg-[var(--page-bg)]">
+    <div className="flex h-full w-full max-w-[390px] flex-col overflow-hidden bg-[var(--page-bg)]">
       <header className="flex w-full items-center justify-between px-6 pt-4">
         <button
           type="button"
@@ -61,7 +61,7 @@ export default function AttemptReview({
         </span>
       </div>
 
-      <section className="flex flex-1 flex-col gap-4 overflow-y-auto px-6 pb-6">
+      <section className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 pb-6">
         {questions.map((q) => (
           <ReviewQuestionCard key={q.number} question={q} />
         ))}

--- a/frontend/app/components/quiz/results/QuizResults.tsx
+++ b/frontend/app/components/quiz/results/QuizResults.tsx
@@ -9,24 +9,24 @@ import ScoreCircle from './ScoreCircle';
 
 interface QuizResultsProps {
   scorePercent: number;
-  scoreCorrect: number;
+  scorePoints: number;
   scoreTotal: number;
   message: string;
-  ranking: RankingEntry[];
+  ranking?: RankingEntry[];
+  showAnswerReview?: boolean;
   onRetry?: () => void;
   onReview?: () => void;
-  onBack?: () => void;
 }
 
 export default function QuizResults({
   scorePercent,
-  scoreCorrect,
+  scorePoints,
   scoreTotal,
   message,
   ranking,
+  showAnswerReview = true,
   onRetry,
   onReview,
-  onBack,
 }: QuizResultsProps) {
   return (
     <div className="flex min-h-full w-full max-w-[390px] flex-col bg-[var(--page-bg)]">
@@ -37,29 +37,50 @@ export default function QuizResults({
           </span>
           <ScoreCircle
             percent={scorePercent}
-            correct={scoreCorrect}
+            correct={scorePoints}
             total={scoreTotal}
           />
           <p className="max-w-[280px] text-center text-[15px] leading-[1.5] font-medium text-[var(--text-dark)]">
             {message}
           </p>
+          <div className="w-full max-w-[280px] rounded-2xl border border-[var(--border)] bg-[var(--card-bg)] px-4 py-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-[var(--text-muted)]">
+                Punkty
+              </span>
+              <span className="font-semibold text-[var(--text-dark)]">
+                {scorePoints} / {scoreTotal}
+              </span>
+            </div>
+            <div className="my-2 h-px bg-[var(--border)]" />
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-[var(--text-muted)]">
+                Procent
+              </span>
+              <span className="font-semibold text-[var(--text-dark)]">
+                {scorePercent}%
+              </span>
+            </div>
+          </div>
         </section>
 
-        <section className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card-bg)]">
-          <div className="px-4 py-3.5">
-            <h2 className="text-[15px] font-bold text-[var(--text-dark)]">
-              Ranking Wydziałowy
-            </h2>
-          </div>
-          <div className="h-px bg-[var(--border)]" />
-          {ranking.map((entry, idx) => (
-            <RankingRow
-              key={entry.position}
-              entry={entry}
-              isLast={idx === ranking.length - 1}
-            />
-          ))}
-        </section>
+        {ranking && ranking.length > 0 && (
+          <section className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card-bg)]">
+            <div className="px-4 py-3.5">
+              <h2 className="text-[15px] font-bold text-[var(--text-dark)]">
+                Ranking Wydziałowy
+              </h2>
+            </div>
+            <div className="h-px bg-[var(--border)]" />
+            {ranking.map((entry, idx) => (
+              <RankingRow
+                key={entry.position}
+                entry={entry}
+                isLast={idx === ranking.length - 1}
+              />
+            ))}
+          </section>
+        )}
 
         <nav className="flex flex-col items-center gap-3">
           <button
@@ -72,22 +93,26 @@ export default function QuizResults({
             </span>
           </button>
 
-          <button
-            onClick={onReview}
-            className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border-[1.5px] border-[var(--border)] bg-[var(--card-bg)] px-6 py-3.5 transition-opacity hover:opacity-90"
-          >
-            <FileCheck size={18} className="text-[var(--text-dark)]" />
-            <span className="text-[15px] font-semibold text-[var(--text-dark)]">
-              Przejrzyj odpowiedzi
-            </span>
-          </button>
+          {showAnswerReview && (
+            <button
+              onClick={onReview}
+              className="flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl border-[1.5px] border-[var(--border)] bg-[var(--card-bg)] px-6 py-3.5 transition-opacity hover:opacity-90"
+            >
+              <FileCheck size={18} className="text-[var(--text-dark)]" />
+              <span className="text-[15px] font-semibold text-[var(--text-dark)]">
+                Przejrzyj odpowiedzi
+              </span>
+            </button>
+          )}
 
-          <button
-            onClick={onBack}
-            className="cursor-pointer text-sm font-medium text-[var(--text-muted)] hover:underline"
+          <a
+            href="https://www.informatyka.agh.edu.pl"
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm font-medium text-[var(--text-muted)] hover:underline"
           >
-            Wróć do strony Wydziału
-          </button>
+            Zobacz stronę Wydziału Informatyki AGH!
+          </a>
         </nav>
       </div>
     </div>

--- a/frontend/app/data/demo.ts
+++ b/frontend/app/data/demo.ts
@@ -99,7 +99,7 @@ export const rangeSliderDemo = {
 
 export const quizResultsDemo = {
   scorePercent: 78,
-  scoreCorrect: 8,
+  scorePoints: 8,
   scoreTotal: 10,
   message: 'Świetny wynik! Jesteś w czołówce wydziału.',
   ranking: [

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -55,10 +55,10 @@ export default function Home() {
   const isAdmin = ['Admin Panel', 'Quiz Detail', 'Quiz Editor'].includes(
     current,
   );
+  const shouldCenterVertically = !isAdmin && current !== 'Attempt Review';
 
   return (
     <div className="flex h-screen flex-col">
-      {/* Navigation */}
       <nav className="flex flex-wrap gap-2 border-b border-[var(--border)] bg-[var(--card-bg)] p-3">
         {screens.map((screen) => (
           <button
@@ -75,9 +75,8 @@ export default function Home() {
         ))}
       </nav>
 
-      {/* Screen */}
       <div
-        className={`flex flex-1 overflow-auto bg-[var(--page-bg)] ${isAdmin ? '' : 'items-center justify-center'}`}
+        className={`flex flex-1 overflow-auto bg-[var(--page-bg)] ${shouldCenterVertically ? 'items-center justify-center' : 'justify-center'}`}
       >
         {current === 'Quiz Start' && <QuizStart {...quizStartDemo} />}
         {current === 'Single Choice' && <SingleChoice {...singleChoiceDemo} />}

--- a/frontend/app/quiz-demo/page.tsx
+++ b/frontend/app/quiz-demo/page.tsx
@@ -1,0 +1,443 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  AttemptReview,
+  ImageAnswers,
+  ImageQuestion,
+  MultipleChoice,
+  Ordering,
+  QuizResults,
+  QuizStart,
+  RangeSlider,
+  SingleChoice,
+  SliderQuestion,
+} from '../components/quiz';
+import type { ImageAnswerOption, ReviewQuestion } from '../types';
+
+const quizStartData = {
+  title: 'Quiz Informatyczny',
+  description:
+    'Sprawdź swoją wiedzę z zakresu informatyki! Odpowiedz na pytania i zobacz wynik zaraz po zakończeniu quizu.',
+  logoUrl: '/images/wi-new-logo.png',
+};
+
+type QuizQuestion =
+  | {
+      id: number;
+      type: 'single' | 'multiple';
+      question: string;
+      answers: string[];
+      hint?: string;
+    }
+  | {
+      id: number;
+      type: 'image-question';
+      question: string;
+      imageUrl: string;
+      answers: string[];
+    }
+  | {
+      id: number;
+      type: 'image-answers';
+      question: string;
+      answers: ImageAnswerOption[];
+    }
+  | {
+      id: number;
+      type: 'ordering';
+      question: string;
+      hint?: string;
+      items: string[];
+    }
+  | {
+      id: number;
+      type: 'slider';
+      question: string;
+      hint?: string;
+      min: number;
+      max: number;
+      step: number;
+      defaultValue: number;
+      unit: string;
+      ticks: number[];
+    }
+  | {
+      id: number;
+      type: 'range-slider';
+      question: string;
+      hint?: string;
+      min: number;
+      max: number;
+      defaultValue: number;
+      lowLabel: string;
+      highLabel: string;
+    };
+
+type SubmittedAnswer = {
+  questionId: number;
+  selected?: number[];
+  ordering?: string[];
+  value?: number;
+};
+
+const questions: QuizQuestion[] = [
+  {
+    id: 1,
+    type: 'single' as const,
+    question:
+      'Który protokół jest używany do bezpiecznego przesyłania danych w sieci?',
+    answers: ['HTTP', 'HTTPS', 'FTP', 'SMTP'],
+  },
+  {
+    id: 2,
+    type: 'multiple' as const,
+    question: 'Które z poniższych są językami programowania?',
+    hint: 'Wybierz wszystkie poprawne odpowiedzi',
+    answers: ['Python', 'HTML', 'Java', 'CSS'],
+  },
+  {
+    id: 3,
+    type: 'image-question',
+    question: 'Który schemat blokowy przedstawia pętlę while?',
+    imageUrl: '/images/flowchart.png',
+    answers: ['Schemat A', 'Schemat B', 'Schemat C'],
+  },
+  {
+    id: 4,
+    type: 'image-answers',
+    question: 'Który obraz przedstawia strukturę drzewa binarnego?',
+    answers: [
+      { imageUrl: '/images/diagram-a.png', label: 'A' },
+      { imageUrl: '/images/diagram-b.png', label: 'B' },
+      { imageUrl: '/images/diagram-c.png', label: 'C' },
+      { imageUrl: '/images/diagram-d.png', label: 'D' },
+    ],
+  },
+  {
+    id: 5,
+    type: 'ordering',
+    question: 'Ułóż etapy kompilacji programu w odpowiedniej kolejności',
+    hint: 'Przeciągnij elementy, aby ustalić kolejność',
+    items: [
+      'Analiza leksykalna',
+      'Analiza składniowa',
+      'Optymalizacja',
+      'Generowanie kodu',
+    ],
+  },
+  {
+    id: 6,
+    type: 'slider',
+    question: 'Ile bitów ma adres IPv4?',
+    hint: 'Wybierz wartość za pomocą suwaka',
+    min: 0,
+    max: 128,
+    step: 1,
+    defaultValue: 32,
+    unit: 'bitów',
+    ticks: [0, 32, 64, 96, 128],
+  },
+  {
+    id: 7,
+    type: 'range-slider',
+    question: 'Oceń swoją pewność w zakresie programowania obiektowego',
+    hint: 'Przesuń suwak, aby wybrać wartość od 1 do 10',
+    min: 1,
+    max: 10,
+    defaultValue: 7,
+    lowLabel: 'Niska pewność',
+    highLabel: 'Wysoka pewność',
+  },
+];
+
+interface QuizResultsApiResponse {
+  scorePercent: number;
+  scorePoints: number;
+  scoreMaxPoints: number;
+  correct: number;
+  scoreTotal: number;
+  showAnswerReview: boolean;
+  message: string;
+  reviewQuestions: ReviewQuestion[];
+}
+
+type View = 'start' | 'question' | 'results' | 'review';
+
+export default function QuizDemoPage() {
+  const [view, setView] = useState<View>('start');
+  const [questionIndex, setQuestionIndex] = useState(0);
+  const [submittedAnswers, setSubmittedAnswers] = useState<SubmittedAnswer[]>(
+    [],
+  );
+  const [result, setResult] = useState<QuizResultsApiResponse | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const currentQuestion = questions[questionIndex];
+  const totalQuestions = questions.length;
+
+  const submitQuiz = async (answers: SubmittedAnswer[]) => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+
+    try {
+      const backendBaseUrl =
+        process.env.NEXT_PUBLIC_BACKEND_URL ?? 'http://127.0.0.1:8000';
+
+      const response = await fetch(`${backendBaseUrl}/quiz/results`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ answers }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch quiz results (${response.status})`);
+      }
+
+      const data = (await response.json()) as QuizResultsApiResponse;
+      setResult(data);
+      setView('results');
+    } catch (error) {
+      console.error('Quiz results fetch failed:', error);
+      setSubmitError('Nie udało się pobrać wyników. Spróbuj ponownie.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleAnswerSubmit = async (
+    answer: Omit<SubmittedAnswer, 'questionId'>,
+  ) => {
+    const nextAnswers = [
+      ...submittedAnswers.filter(
+        (submitted) => submitted.questionId !== currentQuestion.id,
+      ),
+      {
+        questionId: currentQuestion.id,
+        ...answer,
+      },
+    ];
+
+    setSubmittedAnswers(nextAnswers);
+
+    const isLastQuestion = questionIndex === totalQuestions - 1;
+
+    if (isLastQuestion) {
+      await submitQuiz(nextAnswers);
+      return;
+    }
+
+    setQuestionIndex((prev) => prev + 1);
+  };
+
+  const resetQuiz = () => {
+    setView('start');
+    setQuestionIndex(0);
+    setSubmittedAnswers([]);
+    setResult(null);
+    setIsSubmitting(false);
+    setSubmitError(null);
+  };
+
+  if (isSubmitting) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--page-bg)] px-6">
+        <p className="text-base font-semibold text-[var(--text-dark)]">
+          Przeliczanie wyniku...
+        </p>
+      </div>
+    );
+  }
+
+  if (view === 'start') {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--page-bg)]">
+        <QuizStart {...quizStartData} onStart={() => setView('question')} />
+      </div>
+    );
+  }
+
+  if (view === 'question' && currentQuestion) {
+    let questionView = null;
+
+    if (currentQuestion.type === 'single') {
+      questionView = (
+        <SingleChoice
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          answers={currentQuestion.answers}
+          onSubmit={(selectedIndex) =>
+            handleAnswerSubmit({ selected: [selectedIndex] })
+          }
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'multiple') {
+      questionView = (
+        <MultipleChoice
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          hint={currentQuestion.hint}
+          answers={currentQuestion.answers}
+          onSubmit={(selectedIndices) =>
+            handleAnswerSubmit({ selected: selectedIndices })
+          }
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'image-question') {
+      questionView = (
+        <ImageQuestion
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          imageUrl={currentQuestion.imageUrl}
+          answers={currentQuestion.answers}
+          onSubmit={(selectedIndex) =>
+            handleAnswerSubmit({ selected: [selectedIndex] })
+          }
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'image-answers') {
+      questionView = (
+        <ImageAnswers
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          answers={currentQuestion.answers}
+          onSubmit={(selectedIndex) =>
+            handleAnswerSubmit({ selected: [selectedIndex] })
+          }
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'ordering') {
+      questionView = (
+        <Ordering
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          hint={currentQuestion.hint}
+          items={currentQuestion.items}
+          onSubmit={(order) => handleAnswerSubmit({ ordering: order })}
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'slider') {
+      questionView = (
+        <SliderQuestion
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          hint={currentQuestion.hint}
+          min={currentQuestion.min}
+          max={currentQuestion.max}
+          step={currentQuestion.step}
+          defaultValue={currentQuestion.defaultValue}
+          unit={currentQuestion.unit}
+          ticks={currentQuestion.ticks}
+          onSubmit={(value) => handleAnswerSubmit({ value })}
+        />
+      );
+    }
+
+    if (currentQuestion.type === 'range-slider') {
+      questionView = (
+        <RangeSlider
+          questionNumber={questionIndex + 1}
+          totalQuestions={totalQuestions}
+          time="--:--"
+          question={currentQuestion.question}
+          hint={currentQuestion.hint}
+          min={currentQuestion.min}
+          max={currentQuestion.max}
+          defaultValue={currentQuestion.defaultValue}
+          lowLabel={currentQuestion.lowLabel}
+          highLabel={currentQuestion.highLabel}
+          onSubmit={(value) => handleAnswerSubmit({ value })}
+        />
+      );
+    }
+
+    if (!questionView) {
+      return (
+        <div className="flex h-screen items-center justify-center bg-[var(--page-bg)] px-6">
+          <p className="text-base font-semibold text-[var(--text-dark)]">
+            Nieobsługiwany typ pytania.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--page-bg)]">
+        <div className="flex flex-col items-center gap-3">
+          {questionView}
+          {submitError && (
+            <p className="text-sm font-medium text-[var(--wrong-fg)]">
+              {submitError}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (view === 'review' && result?.showAnswerReview) {
+    const correctCount = result.reviewQuestions.filter(
+      (q) => q.isCorrect,
+    ).length;
+
+    return (
+      <div className="flex h-screen justify-center overflow-hidden bg-[var(--page-bg)]">
+        <AttemptReview
+          correctCount={correctCount}
+          wrongCount={result.reviewQuestions.length - correctCount}
+          scorePercent={result.scorePercent}
+          questions={result.reviewQuestions}
+          onBack={() => setView('results')}
+        />
+      </div>
+    );
+  }
+
+  if (view === 'results' && result) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[var(--page-bg)]">
+        <QuizResults
+          scorePercent={result.scorePercent}
+          scorePoints={result.scorePoints}
+          scoreTotal={result.scoreMaxPoints}
+          message={result.message}
+          showAnswerReview={result.showAnswerReview}
+          onReview={() => setView('review')}
+          onRetry={resetQuiz}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-[var(--page-bg)]">
+      <p className="text-base font-semibold text-[var(--text-dark)]">
+        Wystąpił błąd podczas ładowania quizu.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
### Implements US 4.2 (RDE-47): result summary shown immediately after quiz completion.

What changed
* Implements US 4.2 frontend flow for immediate post-quiz result summary.
* Displays explicit score summary as Punkty and Procent on the final screen.
* Keeps WI AGH link visible in the completion view.
* Updates quiz demo/API integration to use server-provided result fields for summary display.
* Includes minor results-view layout adjustments for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new interactive quiz demo page with complete quiz workflow: start screen, support for multiple question types, results display with scoring, and detailed answer review functionality.

* **Improvements**
  * Results page ranking section is now conditionally displayed only when applicable.
  * Answer review button visibility can be configured.
  * Updated back navigation to redirect to external website.
  * Improved answer review layout and scrolling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->