### PR TITLE
[RDE-68] feat(admin): add presenter window with QR, PIN, and join link

### DIFF
--- a/frontend/app/admin/presenter/page.tsx
+++ b/frontend/app/admin/presenter/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import ExportedImage from 'next-image-export-optimizer';
+import { Suspense } from 'react';
+
+import { QrCode } from '@/app/components/admin/dashboard/QrCode';
+
+import { resolvePresenterSession } from './presenter-session';
+
+function PresenterFallback() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white p-6">
+      <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-6 text-sm text-[var(--text-muted)]">
+        Ładowanie…
+      </div>
+    </main>
+  );
+}
+
+function PresenterScreen() {
+  const params = useSearchParams();
+  const session = resolvePresenterSession(
+    params.get('pin'),
+    params.get('href'),
+  );
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white p-6">
+      {!session ? (
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--card-bg)] p-6 text-sm text-[var(--text-muted)]">
+          Brak poprawnych danych do wyświetlenia.
+        </div>
+      ) : (
+        <div className="flex w-full max-w-3xl flex-col items-center gap-8 rounded-3xl border border-[var(--border)] bg-[var(--card-bg)] p-8">
+          <ExportedImage
+            src="/images/wi-new-logo.png"
+            alt="Logo Wydziału Informatyki"
+            width={340}
+            height={96}
+            className="h-auto w-full max-w-[320px] object-contain"
+            priority
+          />
+          <QrCode value={session.playHref} size={360} />
+          <div className="text-center font-mono text-5xl tracking-[0.3em] text-[var(--text-dark)]">
+            {session.pin}
+          </div>
+          <a
+            href={session.playHref}
+            target="_blank"
+            rel="noreferrer"
+            className="text-center text-xl break-all text-black underline"
+          >
+            {session.playHref}
+          </a>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export default function PresenterPage() {
+  return (
+    <Suspense fallback={<PresenterFallback />}>
+      <PresenterScreen />
+    </Suspense>
+  );
+}

--- a/frontend/app/admin/presenter/presenter-session.test.ts
+++ b/frontend/app/admin/presenter/presenter-session.test.ts
@@ -51,6 +51,19 @@ test('resolvePresenterSession rejects an invalid participant URL and falls back 
   });
 });
 
+test('resolvePresenterSession rejects participant URLs outside the play route and falls back to pin-only href', () => {
+  assert.deepEqual(
+    resolvePresenterSession(
+      'ab2cd3',
+      'https://quiz.example.edu/other/?code=AB2CD3',
+    ),
+    {
+      pin: 'AB2CD3',
+      playHref: '/play/?code=AB2CD3',
+    },
+  );
+});
+
 test('resolvePresenterSession preserves deployment sub-path from a full participant URL', () => {
   assert.deepEqual(
     resolvePresenterSession(

--- a/frontend/app/admin/presenter/presenter-session.test.ts
+++ b/frontend/app/admin/presenter/presenter-session.test.ts
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  presenterPlayHref,
+  resolvePresenterSession,
+} from './presenter-session';
+
+test('resolvePresenterSession normalizes a valid presenter pin', () => {
+  assert.deepEqual(resolvePresenterSession(' ab2cd3 '), {
+    pin: 'AB2CD3',
+    playHref: '/play/?code=AB2CD3',
+  });
+});
+
+test('resolvePresenterSession prefers a validated participant URL when provided', () => {
+  assert.deepEqual(
+    resolvePresenterSession(
+      'ab2cd3',
+      'https://quiz.example.edu/play/?code=AB2CD3',
+    ),
+    {
+      pin: 'AB2CD3',
+      playHref: 'https://quiz.example.edu/play/?code=AB2CD3',
+    },
+  );
+});
+
+test('resolvePresenterSession builds an absolute participant URL when origin is provided', () => {
+  assert.deepEqual(
+    resolvePresenterSession('ab2cd3', 'https://quiz.example.edu'),
+    {
+      pin: 'AB2CD3',
+      playHref: 'https://quiz.example.edu/play/?code=AB2CD3',
+    },
+  );
+});
+
+test('resolvePresenterSession rejects invalid presenter pins', () => {
+  assert.equal(resolvePresenterSession(null), null);
+  assert.equal(resolvePresenterSession(''), null);
+  assert.equal(resolvePresenterSession('ABC1234'), null);
+  assert.equal(resolvePresenterSession('abc10o'), null);
+  assert.equal(resolvePresenterSession('javascript:alert(1)'), null);
+});
+
+test('resolvePresenterSession rejects an invalid participant URL and falls back to pin-only href', () => {
+  assert.deepEqual(resolvePresenterSession('ab2cd3', 'javascript:alert(1)'), {
+    pin: 'AB2CD3',
+    playHref: '/play/?code=AB2CD3',
+  });
+});
+
+test('resolvePresenterSession preserves deployment sub-path from a full participant URL', () => {
+  assert.deepEqual(
+    resolvePresenterSession(
+      'ab2cd3',
+      'https://quiz.example.edu/cogniro/play/?code=AB2CD3',
+    ),
+    {
+      pin: 'AB2CD3',
+      playHref: 'https://quiz.example.edu/cogniro/play/?code=AB2CD3',
+    },
+  );
+});
+
+test('presenterPlayHref encodes the pin into the participant route', () => {
+  assert.equal(presenterPlayHref('AB2CD3'), '/play/?code=AB2CD3');
+});
+
+test('presenterPlayHref returns absolute URL when origin is valid', () => {
+  assert.equal(
+    presenterPlayHref('AB2CD3', 'https://quiz.example.edu'),
+    'https://quiz.example.edu/play/?code=AB2CD3',
+  );
+});

--- a/frontend/app/admin/presenter/presenter-session.ts
+++ b/frontend/app/admin/presenter/presenter-session.ts
@@ -1,0 +1,115 @@
+const PRESENTER_PIN_RE = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/;
+
+export type PresenterSession = {
+  pin: string;
+  playHref: string;
+};
+
+function normalizePresenterPin(rawPin: string | null): string | null {
+  if (rawPin == null) {
+    return null;
+  }
+
+  const pin = rawPin.trim().toUpperCase();
+  return PRESENTER_PIN_RE.test(pin) ? pin : null;
+}
+
+function normalizePresenterPlayHref(
+  rawHref: string | null | undefined,
+  pin: string,
+): string | null {
+  if (!rawHref) {
+    return null;
+  }
+
+  const trimmed = rawHref.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return null;
+    }
+    const code = normalizePresenterPin(url.searchParams.get('code'));
+    return code === pin ? url.toString() : null;
+  } catch {
+    try {
+      const url = new URL(trimmed, 'https://presenter.invalid');
+      const code = normalizePresenterPin(url.searchParams.get('code'));
+      if (code !== pin) {
+        return null;
+      }
+      return `${url.pathname}${url.search}${url.hash}`;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function normalizePresenterOrigin(
+  rawOrigin: string | null | undefined,
+): string | null {
+  if (!rawOrigin) {
+    return null;
+  }
+
+  const trimmed = rawOrigin.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (
+      (url.protocol !== 'http:' && url.protocol !== 'https:') ||
+      url.pathname !== '/' ||
+      url.search !== '' ||
+      url.hash !== ''
+    ) {
+      return null;
+    }
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+export function presenterPlayHref(pin: string, origin?: string | null): string {
+  const playPath = `/play/?code=${encodeURIComponent(pin)}`;
+  if (!origin) {
+    return playPath;
+  }
+  try {
+    return new URL(playPath, origin).toString();
+  } catch {
+    return playPath;
+  }
+}
+
+export function resolvePresenterSession(
+  rawPin: string | null,
+  playHrefOrOrigin?: string | null,
+): PresenterSession | null {
+  const pin = normalizePresenterPin(rawPin);
+  if (!pin) {
+    return null;
+  }
+
+  const directPlayHref = normalizePresenterPlayHref(playHrefOrOrigin, pin);
+  if (directPlayHref) {
+    return {
+      pin,
+      playHref: directPlayHref,
+    };
+  }
+
+  return {
+    pin,
+    playHref: presenterPlayHref(
+      pin,
+      normalizePresenterOrigin(playHrefOrOrigin),
+    ),
+  };
+}

--- a/frontend/app/admin/presenter/presenter-session.ts
+++ b/frontend/app/admin/presenter/presenter-session.ts
@@ -5,6 +5,10 @@ export type PresenterSession = {
   playHref: string;
 };
 
+function isParticipantPlayPath(pathname: string): boolean {
+  return pathname.endsWith('/play/');
+}
+
 function normalizePresenterPin(rawPin: string | null): string | null {
   if (rawPin == null) {
     return null;
@@ -32,11 +36,17 @@ function normalizePresenterPlayHref(
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
       return null;
     }
+    if (!isParticipantPlayPath(url.pathname)) {
+      return null;
+    }
     const code = normalizePresenterPin(url.searchParams.get('code'));
     return code === pin ? url.toString() : null;
   } catch {
     try {
       const url = new URL(trimmed, 'https://presenter.invalid');
+      if (!isParticipantPlayPath(url.pathname)) {
+        return null;
+      }
       const code = normalizePresenterPin(url.searchParams.get('code'));
       if (code !== pin) {
         return null;

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { ArrowLeft, Ban, CircleStop, RefreshCcw } from 'lucide-react';
+import {
+  ArrowLeft,
+  Ban,
+  CircleStop,
+  Download,
+  ExternalLink,
+  RefreshCcw,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { QrCode } from '@/app/components/admin/dashboard/QrCode';
@@ -22,6 +29,15 @@ import {
 } from '@/lib/sessions/client';
 
 type Snapshot = Awaited<ReturnType<typeof getSessionSnapshot>>;
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error(`Image load failed: ${src}`));
+    image.src = src;
+  });
+}
 
 function formatScoreVsMax(score: number | null, maxScore: number): string {
   if (maxScore <= 0) {
@@ -59,6 +75,108 @@ export function RunningQuizView({
   } | null>(null);
   const [snap, setSnap] = useState<Snapshot | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  const buildPresenterUrl = () => {
+    if (!activation) {
+      return null;
+    }
+    const basePath = window.location.pathname.endsWith('/')
+      ? window.location.pathname
+      : `${window.location.pathname}/`;
+    const presenterUrl = new URL(
+      `${basePath}presenter/`,
+      window.location.origin,
+    );
+    presenterUrl.search = new URLSearchParams({
+      href: activation.join_url,
+      pin: activation.pin,
+    }).toString();
+    return presenterUrl.toString();
+  };
+
+  const openPresenterWindow = () => {
+    const presenterUrl = buildPresenterUrl();
+    if (!presenterUrl) {
+      return;
+    }
+    const popup = window.open(
+      presenterUrl,
+      'quiz-presenter-view',
+      'width=960,height=900',
+    );
+    if (!popup) {
+      window.alert(
+        'Nie udało się otworzyć nowego okna. Sprawdź, czy przeglądarka nie blokuje popupów.',
+      );
+      return;
+    }
+    popup.focus();
+  };
+
+  const downloadPrintableQrBoard = async () => {
+    if (!activation) {
+      return;
+    }
+
+    try {
+      const QRCode = (await import('qrcode')).default;
+      const qrDataUrl = await QRCode.toDataURL(activation.join_url, {
+        width: 1200,
+        margin: 1,
+      });
+
+      const canvas = document.createElement('canvas');
+      canvas.width = 1300;
+      canvas.height = 1800;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        throw new Error('Canvas context unavailable');
+      }
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      try {
+        const logo = await loadImage('/images/wi-new-logo.png');
+        const logoMaxWidth = 740;
+        const logoMaxHeight = 210;
+        const logoScale = Math.min(
+          logoMaxWidth / logo.width,
+          logoMaxHeight / logo.height,
+        );
+        const logoWidth = logo.width * logoScale;
+        const logoHeight = logo.height * logoScale;
+        const logoX = (canvas.width - logoWidth) / 2;
+        const logoY = 90 + (logoMaxHeight - logoHeight) / 2;
+        ctx.drawImage(logo, logoX, logoY, logoWidth, logoHeight);
+      } catch {
+        ctx.fillStyle = '#1f2937';
+        ctx.textAlign = 'center';
+        ctx.font = '56px Arial, sans-serif';
+        ctx.fillText('Wydział Informatyki', 650, 210);
+      }
+
+      const qrImage = await loadImage(qrDataUrl);
+      ctx.drawImage(qrImage, 250, 360, 800, 800);
+
+      ctx.fillStyle = '#111827';
+      ctx.textAlign = 'center';
+      ctx.font = '136px "Courier New", monospace';
+      ctx.fillText(activation.pin, 650, 1270);
+
+      ctx.font = '48px Arial, sans-serif';
+      ctx.fillText(activation.join_url, 650, 1400);
+
+      const url = canvas.toDataURL('image/png');
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `quiz-qr-${activation.pin}.png`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+    } catch {
+      window.alert('Nie udało się przygotować pliku do pobrania.');
+    }
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -165,6 +283,24 @@ export function RunningQuizView({
             <div className="text-sm text-[var(--text-dark)]">
               Aktywny od:{' '}
               {new Date(activation.started_at).toLocaleTimeString('pl-PL')}
+            </div>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button
+                type="button"
+                className={adminToolbarButtonClass}
+                onClick={openPresenterWindow}
+              >
+                <ExternalLink size={14} aria-hidden />
+                Otwórz ekran uczestników
+              </button>
+              <button
+                type="button"
+                className={adminToolbarButtonClass}
+                onClick={() => void downloadPrintableQrBoard()}
+              >
+                <Download size={14} aria-hidden />
+                Pobierz planszę QR
+              </button>
             </div>
           </div>
         </div>

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -39,6 +39,33 @@ function loadImage(src: string): Promise<HTMLImageElement> {
   });
 }
 
+function drawWrappedCenteredText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  centerX: number,
+  startY: number,
+  maxWidth: number,
+  lineHeight: number,
+): void {
+  let currentLine = '';
+  let lineY = startY;
+
+  for (const char of text) {
+    const nextLine = currentLine + char;
+    if (currentLine && ctx.measureText(nextLine).width > maxWidth) {
+      ctx.fillText(currentLine, centerX, lineY);
+      currentLine = char;
+      lineY += lineHeight;
+      continue;
+    }
+    currentLine = nextLine;
+  }
+
+  if (currentLine) {
+    ctx.fillText(currentLine, centerX, lineY);
+  }
+}
+
 function formatScoreVsMax(score: number | null, maxScore: number): string {
   if (maxScore <= 0) {
     return score == null ? '—' : String(score);
@@ -110,6 +137,7 @@ export function RunningQuizView({
       );
       return;
     }
+    popup.opener = null;
     popup.focus();
   };
 
@@ -163,8 +191,8 @@ export function RunningQuizView({
       ctx.font = '136px "Courier New", monospace';
       ctx.fillText(activation.pin, 650, 1270);
 
-      ctx.font = '48px Arial, sans-serif';
-      ctx.fillText(activation.join_url, 650, 1400);
+      ctx.font = '42px Arial, sans-serif';
+      drawWrappedCenteredText(ctx, activation.join_url, 650, 1400, 1100, 56);
 
       const url = canvas.toDataURL('image/png');
       const anchor = document.createElement('a');


### PR DESCRIPTION
Implement RDE-68 like in the PR's title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a presenter view screen displaying session PIN, QR code, and play link
  * Added ability to open presenter screen in a popup window
  * Added option to download a printable QR code board image

* **Tests**
  * Added test coverage for session validation and PIN normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rdest-devs/cogniro/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->