### PR TITLE
[RDE-49] feat: automatyczny filtr wulgarnych nicków (glin-profanity)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pyjwt>=2.12.1",
     "python-dotenv>=1.0.0",
     "uvicorn[standard]>=0.38.0",
+    "glin-profanity>=3.4.0",
 ]
 
 [dependency-groups]

--- a/backend/routes/play.py
+++ b/backend/routes/play.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, StringConstraints
 from schemas.kqf import KqfQuiz
 from services import sessions
 from services.play_rate_limit import enforce_play_rate_limit
+from services.profanity import is_nickname_allowed
 from services.quiz_files import (
     kqf_with_absolute_media,
     max_points_from_quiz_dir,
@@ -53,6 +54,16 @@ async def play_join(pin: str, body: JoinBody, request: Request) -> KqfQuiz:
     session = sessions.lookup_by_pin(pin)
     if session is None:
         raise HTTPException(status_code=404, detail="pin_not_active")
+    if not is_nickname_allowed(body.nickname):
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "nickname_profanity",
+                "detail_pl": (
+                    "Ten pseudonim zawiera niedozwolone słowa. Wybierz inny."
+                ),
+            },
+        )
     try:
         await run_in_threadpool(
             sessions.register_participant, pin=pin, nickname=body.nickname

--- a/backend/services/profanity.py
+++ b/backend/services/profanity.py
@@ -1,0 +1,40 @@
+"""Automatic nickname moderation.
+
+Wraps `glin-profanity <https://pypi.org/project/glin-profanity/>`_ to reject
+vulgar nicknames in Polish and English before a participant joins a session.
+
+The previous placeholder implementation always accepted every nickname; this
+module replaces it with a real profanity check. The detection uses the library
+default of word-boundary matching (no aggressive obfuscation matching) so that
+legitimate nicknames containing an embedded short word (e.g. "assassin",
+"classic") are not flagged as false positives. Admins can still manually block
+anything the automatic filter lets through.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from glin_profanity import Filter
+
+# Languages the automatic filter screens against. Polish is the primary
+# audience; English is included because vulgar English nicknames are common.
+_LANGUAGES = ["polish", "english"]
+
+
+@lru_cache(maxsize=1)
+def _filter() -> Filter:
+    """Build the profanity filter once and reuse it across requests."""
+    return Filter({"languages": _LANGUAGES})
+
+
+def is_nickname_allowed(nickname: str) -> bool:
+    """Return ``True`` when the nickname is clean (contains no profanity).
+
+    An empty/whitespace-only nickname is treated as allowed here; length and
+    emptiness are enforced separately by the request schema.
+    """
+    text = nickname.strip()
+    if not text:
+        return True
+    return not _filter().is_profane(text)

--- a/backend/tests/test_play.py
+++ b/backend/tests/test_play.py
@@ -114,6 +114,31 @@ def test_join_strips_nickname_whitespace(
     assert r.status_code == 200
 
 
+def test_join_rejects_vulgar_nickname_returns_400(
+    client: TestClient, admin_token_header: dict[str, str]
+) -> None:
+    quiz_id = _create_quiz(client, admin_token_header)
+    pin = client.post(
+        f"/admin/quiz/{quiz_id}/activate", headers=admin_token_header
+    ).json()["pin"]
+    r = client.post(f"/play/{pin}/join", json={"nickname": "kurwa"})
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "nickname_profanity"
+
+
+def test_join_allows_clean_nickname_after_vulgar_rejected(
+    client: TestClient, admin_token_header: dict[str, str]
+) -> None:
+    quiz_id = _create_quiz(client, admin_token_header)
+    pin = client.post(
+        f"/admin/quiz/{quiz_id}/activate", headers=admin_token_header
+    ).json()["pin"]
+    assert (
+        client.post(f"/play/{pin}/join", json={"nickname": "chuj"}).status_code == 400
+    )
+    assert client.post(f"/play/{pin}/join", json={"nickname": "Ala"}).status_code == 200
+
+
 def test_duplicate_nickname_returns_409(
     client: TestClient, admin_token_header: dict[str, str]
 ) -> None:

--- a/backend/tests/test_profanity.py
+++ b/backend/tests/test_profanity.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from services.profanity import is_nickname_allowed
+
+
+@pytest.mark.parametrize(
+    "nickname",
+    ["Ala", "Bartek123", "Mateusz", "Kacper", "assassin", "classic", "grass", ""],
+)
+def test_clean_nicknames_are_allowed(nickname: str) -> None:
+    assert is_nickname_allowed(nickname) is True
+
+
+@pytest.mark.parametrize(
+    "nickname",
+    ["kurwa", "kurw4", "chuj", "pizda", "cipa", "dupek", "fuck", "shit"],
+)
+def test_vulgar_nicknames_are_rejected(nickname: str) -> None:
+    assert is_nickname_allowed(nickname) is False
+
+
+def test_surrounding_whitespace_is_ignored() -> None:
+    assert is_nickname_allowed("  kurwa  ") is False
+    assert is_nickname_allowed("  Ala  ") is True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -39,6 +39,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "bcrypt" },
     { name = "fastapi" },
+    { name = "glin-profanity" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pyjwt" },
@@ -59,6 +60,7 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=5.0.0" },
     { name = "fastapi", specifier = ">=0.135.3" },
+    { name = "glin-profanity", specifier = ">=3.4.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pyjwt", specifier = ">=2.12.1" },
@@ -170,6 +172,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "glin-profanity"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/ec/df1f26ff85af5e5071489cfdc199509998f3b1113873548f5b4ccd0cdb25/glin_profanity-3.4.0.tar.gz", hash = "sha256:7304b82b3c816b6526cc048ae50d8daf39caac5b55c953ee4c360f6f95c5bc4d", size = 61118, upload-time = "2026-04-21T03:13:00.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/06/4060c23a4790433a18ef1346c227ed61de0ea82f231436cd1c4d6711700c/glin_profanity-3.4.0-py3-none-any.whl", hash = "sha256:4712a211270f4747b9a2888bce71c5fee9e0b818e38877581bf87dc691ff68aa", size = 76844, upload-time = "2026-04-21T03:13:01.983Z" },
 ]
 
 [[package]]

--- a/frontend/app/play/page.tsx
+++ b/frontend/app/play/page.tsx
@@ -93,7 +93,11 @@ function PlayExperience({ urlCode }: { urlCode: string }) {
             try {
               const r = await joinPlay(stage.code, nickname);
               if (!r.ok) {
-                if (r.status === 409) {
+                if (r.status === 400 && r.profanity) {
+                  setJoinError(
+                    'Ten pseudonim zawiera niedozwolone słowa. Wybierz inny.',
+                  );
+                } else if (r.status === 409) {
                   setJoinError('Ten pseudonim jest już zajęty.');
                 } else if (r.status === 404) {
                   setJoinError('Ten quiz nie jest już aktywny. Sprawdź kod.');

--- a/frontend/lib/play/client.test.ts
+++ b/frontend/lib/play/client.test.ts
@@ -1,0 +1,50 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, test } from 'node:test';
+
+import { joinPlay } from '@/lib/play/client';
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stubFetch(status: number, body: unknown): void {
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch;
+}
+
+test('joinPlay flags profanity on 400 nickname_profanity', async () => {
+  stubFetch(400, {
+    detail: { error: 'nickname_profanity', detail_pl: 'niedozwolone' },
+  });
+  const r = await joinPlay('ABC123', 'kurwa');
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 400);
+    assert.equal(r.profanity, true);
+  }
+});
+
+test('joinPlay does not flag profanity on unrelated 400', async () => {
+  stubFetch(400, { detail: 'something else' });
+  const r = await joinPlay('ABC123', 'Ala');
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 400);
+    assert.notEqual(r.profanity, true);
+  }
+});
+
+test('joinPlay passes through a 409 taken nickname', async () => {
+  stubFetch(409, { detail: 'nickname_taken' });
+  const r = await joinPlay('ABC123', 'Ala');
+  assert.equal(r.ok, false);
+  if (!r.ok) {
+    assert.equal(r.status, 409);
+    assert.notEqual(r.profanity, true);
+  }
+});

--- a/frontend/lib/play/client.ts
+++ b/frontend/lib/play/client.ts
@@ -3,7 +3,7 @@ import { type KqfQuiz, kqfQuizSchema } from '@/lib/kqf';
 
 export type JoinResult =
   | { ok: true; quiz: KqfQuiz }
-  | { ok: false; status: number };
+  | { ok: false; status: number; profanity?: boolean };
 
 export type SubmitResult =
   | { ok: true }
@@ -24,6 +24,24 @@ export async function joinPlay(
     return { ok: false, status: 0 };
   }
   if (!r.ok) {
+    if (r.status === 400) {
+      try {
+        const body = (await r.json()) as {
+          detail?: { error?: string } | string;
+        };
+        const d = body?.detail;
+        if (
+          typeof d === 'object' &&
+          d !== null &&
+          'error' in d &&
+          d.error === 'nickname_profanity'
+        ) {
+          return { ok: false, status: 400, profanity: true };
+        }
+      } catch {
+        /* fallthrough */
+      }
+    }
     return { ok: false, status: r.status };
   }
   let payload: unknown;


### PR DESCRIPTION
## US 4.5 — Moderacja nicków

> Jako administrator, chcę, aby system automatycznie blokował wulgarne nicki, a także żebym mógł ręcznie ukryć lub zablokować nieodpowiednie nazwy.

### Co wprowadza ten MR
Wprowadza [`glin-profanity`](https://pypi.org/project/glin-profanity/) **3.4.0** jako serwis automatycznej moderacji nicków, zastępując dotychczasowe bezwarunkowe przyjmowanie każdego pseudonimu.

- **`backend/services/profanity.py`** (nowy) — `is_nickname_allowed()` oparty o `glin_profanity.Filter` (PL + EN), dopasowanie po granicach słów (bez agresywnej obfuskacji), by uniknąć false-positive na `assassin`/`classic`/`grass`.
- **`POST /play/{pin}/join`** — wulgarny nick odrzucany z **HTTP 400** i kodem `nickname_profanity`.
- **Frontend** — `joinPlay` parsuje 400, `EnterNickname` pokazuje komunikat: „Ten pseudonim zawiera niedozwolone słowa. Wybierz inny.”

### Kryteria akceptacji
- ✅ Automatyczny filtr blokuje wpisanie wulgarnego nicku.
- ✅ Admin może ręcznie zablokować nick z panelu (istniejący przycisk *Blokuj*).
- ✅ Zablokowany uczestnik widzi stosowny komunikat.

### Testy
- `backend/tests/test_profanity.py`, `backend/tests/test_play.py`, `frontend/lib/play/client.test.ts`.
- Backend 191 ✅ · Frontend 46 ✅ · ruff + eslint + tsc ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nickname profanity validation. Users attempting to join a quiz session with disallowed nicknames will receive an error message and be unable to proceed.

* **Tests**
  * Added comprehensive test coverage for nickname profanity detection, including whitespace handling and various profane terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->