### PR TITLE
[RDE-67] - Dodać sortowanie leaderboarda i wyników po score

### DIFF
--- a/frontend/app/components/admin/dashboard/QuizDetail.tsx
+++ b/frontend/app/components/admin/dashboard/QuizDetail.tsx
@@ -1,9 +1,6 @@
 'use client';
 import {
   Calendar,
-  ChevronDown,
-  ChevronsUpDown,
-  ChevronUp,
   Download,
   Eye,
   List,
@@ -14,9 +11,12 @@ import {
 import { useRouter } from 'next/navigation';
 import { useCallback, useMemo, useState } from 'react';
 
+import { SortableTh } from '@/app/components/common/SortableTh';
 import StatusBadge from '@/app/components/common/StatusBadge';
 import type { QuizInfo, ResultRow } from '@/app/types';
+import { useSortableColumns } from '@/hooks/useSortableColumns';
 import { AdminQuizApiError, deleteAdminQuiz } from '@/lib/admin-quiz';
+import { parseResultDate, parseTimeSeconds } from '@/lib/admin-result-sort';
 import { downloadExport } from '@/lib/import-export/client';
 
 import AdminLayout from '../layout/AdminLayout';
@@ -30,58 +30,13 @@ import {
 } from '../shared/constants';
 
 type SortKey = 'name' | 'score' | 'time' | 'date';
-type SortDir = 'asc' | 'desc';
 
-/** Polish month abbreviations used in the demo result rows (e.g. "12 mar 2026"). */
-const PL_MONTHS: Record<string, number> = {
-  sty: 0,
-  lut: 1,
-  mar: 2,
-  kwi: 3,
-  maj: 4,
-  cze: 5,
-  lip: 6,
-  sie: 7,
-  wrz: 8,
-  paź: 9,
-  paz: 9,
-  lis: 10,
-  gru: 11,
-};
-
-/** Parses a "M:SS" / "MM:SS" / "H:MM:SS" duration into total seconds. */
-function parseTimeSeconds(value: string): number {
-  const parts = value.split(':').map((p) => Number(p.trim()));
-  if (parts.some((n) => Number.isNaN(n))) {
-    return Number.NaN;
-  }
-  return parts.reduce((acc, n) => acc * 60 + n, 0);
-}
-
-/** Parses a "D mon YYYY" Polish date (e.g. "6 mar 2026") into a timestamp. */
-function parseResultDate(value: string): number {
-  const match = /^(\d{1,2})\s+([^\s]+)\s+(\d{4})$/.exec(value.trim());
-  if (!match) {
-    const fallback = Date.parse(value);
-    return Number.isNaN(fallback) ? Number.NaN : fallback;
-  }
-  const day = Number(match[1]);
-  const month = PL_MONTHS[match[2].toLowerCase()];
-  const year = Number(match[3]);
-  if (month === undefined) {
-    return Number.NaN;
-  }
-  const date = new Date(year, month, day);
-  // Reject overflowed dates (e.g. "31 kwi") that Date silently normalizes.
-  if (
-    date.getFullYear() !== year ||
-    date.getMonth() !== month ||
-    date.getDate() !== day
-  ) {
-    return Number.NaN;
-  }
-  return date.getTime();
-}
+const SORT_COLUMNS = [
+  { key: 'name', label: 'Imię' },
+  { key: 'score', label: 'Wynik' },
+  { key: 'time', label: 'Czas' },
+  { key: 'date', label: 'Data' },
+] satisfies { key: SortKey; label: string }[];
 
 interface QuizDetailProps {
   quizzes: QuizInfo[];
@@ -178,11 +133,10 @@ export default function QuizDetail({
     [router, adminBase, onQuizDeleted],
   );
 
-  const [sortKey, setSortKey] = useState<SortKey>('score');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const sort = useSortableColumns<SortKey>({ initialKey: 'score' });
 
   const sortedResults = useMemo(() => {
-    const dir = sortDir === 'asc' ? 1 : -1;
+    const dir = sort.sortDir === 'asc' ? 1 : -1;
     /** Compares two numbers, always sorting NaN (invalid) values last regardless of direction. */
     const compareNumeric = (av: number, bv: number) => {
       const aNaN = Number.isNaN(av);
@@ -191,37 +145,19 @@ export default function QuizDetail({
       return (av - bv) * dir;
     };
     return [...resultsForQuiz].sort((a, b) => {
-      if (sortKey === 'score') return (a.score - b.score) * dir;
-      if (sortKey === 'name') return a.name.localeCompare(b.name, 'pl') * dir;
-      if (sortKey === 'time')
+      if (sort.sortKey === 'score') return (a.score - b.score) * dir;
+      if (sort.sortKey === 'name')
+        return a.name.localeCompare(b.name, 'pl') * dir;
+      if (sort.sortKey === 'time')
         return compareNumeric(
           parseTimeSeconds(a.time),
           parseTimeSeconds(b.time),
         );
-      if (sortKey === 'date')
+      if (sort.sortKey === 'date')
         return compareNumeric(parseResultDate(a.date), parseResultDate(b.date));
       return 0;
     });
-  }, [resultsForQuiz, sortKey, sortDir]);
-
-  function handleSort(key: SortKey) {
-    if (sortKey === key) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortKey(key);
-      setSortDir(key === 'score' ? 'desc' : 'asc');
-    }
-  }
-
-  function SortIcon({ col }: { col: SortKey }) {
-    if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
-    return sortDir === 'asc' ? (
-      <ChevronUp size={13} aria-hidden />
-    ) : (
-      <ChevronDown size={13} aria-hidden />
-    );
-  }
+  }, [resultsForQuiz, sort.sortKey, sort.sortDir]);
 
   return (
     <AdminLayout
@@ -336,34 +272,14 @@ export default function QuizDetail({
             <table className={adminBlueHeadTableClass}>
               <thead className={adminBlueHeadTableTheadClass}>
                 <tr>
-                  {(
-                    [
-                      { key: 'name', label: 'Imię' },
-                      { key: 'score', label: 'Wynik' },
-                      { key: 'time', label: 'Czas' },
-                      { key: 'date', label: 'Data' },
-                    ] as { key: SortKey; label: string }[]
-                  ).map(({ key, label }) => (
-                    <th
+                  {SORT_COLUMNS.map(({ key, label }) => (
+                    <SortableTh
                       key={key}
-                      aria-sort={
-                        sortKey === key
-                          ? sortDir === 'asc'
-                            ? 'ascending'
-                            : 'descending'
-                          : 'none'
-                      }
+                      columnKey={key}
+                      label={label}
+                      sort={sort}
                       className={adminBlueHeadTableThClass}
-                    >
-                      <button
-                        type="button"
-                        onClick={() => handleSort(key)}
-                        className="flex cursor-pointer items-center gap-1 hover:opacity-80"
-                      >
-                        {label}
-                        <SortIcon col={key} />
-                      </button>
-                    </th>
+                    />
                   ))}
                 </tr>
               </thead>

--- a/frontend/app/components/admin/dashboard/QuizDetail.tsx
+++ b/frontend/app/components/admin/dashboard/QuizDetail.tsx
@@ -71,7 +71,16 @@ function parseResultDate(value: string): number {
   if (month === undefined) {
     return Number.NaN;
   }
-  return new Date(year, month, day).getTime();
+  const date = new Date(year, month, day);
+  // Reject overflowed dates (e.g. "31 kwi") that Date silently normalizes.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return Number.NaN;
+  }
+  return date.getTime();
 }
 
 interface QuizDetailProps {
@@ -173,18 +182,25 @@ export default function QuizDetail({
   const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   const sortedResults = useMemo(() => {
+    const dir = sortDir === 'asc' ? 1 : -1;
+    /** Compares two numbers, always sorting NaN (invalid) values last regardless of direction. */
+    const compareNumeric = (av: number, bv: number) => {
+      const aNaN = Number.isNaN(av);
+      const bNaN = Number.isNaN(bv);
+      if (aNaN || bNaN) return aNaN === bNaN ? 0 : aNaN ? 1 : -1;
+      return (av - bv) * dir;
+    };
     return [...resultsForQuiz].sort((a, b) => {
-      let cmp = 0;
-      if (sortKey === 'score') {
-        cmp = a.score - b.score;
-      } else if (sortKey === 'name') {
-        cmp = a.name.localeCompare(b.name, 'pl');
-      } else if (sortKey === 'time') {
-        cmp = parseTimeSeconds(a.time) - parseTimeSeconds(b.time);
-      } else if (sortKey === 'date') {
-        cmp = parseResultDate(a.date) - parseResultDate(b.date);
-      }
-      return sortDir === 'asc' ? cmp : -cmp;
+      if (sortKey === 'score') return (a.score - b.score) * dir;
+      if (sortKey === 'name') return a.name.localeCompare(b.name, 'pl') * dir;
+      if (sortKey === 'time')
+        return compareNumeric(
+          parseTimeSeconds(a.time),
+          parseTimeSeconds(b.time),
+        );
+      if (sortKey === 'date')
+        return compareNumeric(parseResultDate(a.date), parseResultDate(b.date));
+      return 0;
     });
   }, [resultsForQuiz, sortKey, sortDir]);
 
@@ -199,11 +215,11 @@ export default function QuizDetail({
 
   function SortIcon({ col }: { col: SortKey }) {
     if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" />;
+      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
     return sortDir === 'asc' ? (
-      <ChevronUp size={13} />
+      <ChevronUp size={13} aria-hidden />
     ) : (
-      <ChevronDown size={13} />
+      <ChevronDown size={13} aria-hidden />
     );
   }
 
@@ -328,7 +344,17 @@ export default function QuizDetail({
                       { key: 'date', label: 'Data' },
                     ] as { key: SortKey; label: string }[]
                   ).map(({ key, label }) => (
-                    <th key={key} className={adminBlueHeadTableThClass}>
+                    <th
+                      key={key}
+                      aria-sort={
+                        sortKey === key
+                          ? sortDir === 'asc'
+                            ? 'ascending'
+                            : 'descending'
+                          : 'none'
+                      }
+                      className={adminBlueHeadTableThClass}
+                    >
                       <button
                         type="button"
                         onClick={() => handleSort(key)}

--- a/frontend/app/components/admin/dashboard/QuizDetail.tsx
+++ b/frontend/app/components/admin/dashboard/QuizDetail.tsx
@@ -32,6 +32,48 @@ import {
 type SortKey = 'name' | 'score' | 'time' | 'date';
 type SortDir = 'asc' | 'desc';
 
+/** Polish month abbreviations used in the demo result rows (e.g. "12 mar 2026"). */
+const PL_MONTHS: Record<string, number> = {
+  sty: 0,
+  lut: 1,
+  mar: 2,
+  kwi: 3,
+  maj: 4,
+  cze: 5,
+  lip: 6,
+  sie: 7,
+  wrz: 8,
+  paź: 9,
+  paz: 9,
+  lis: 10,
+  gru: 11,
+};
+
+/** Parses a "M:SS" / "MM:SS" / "H:MM:SS" duration into total seconds. */
+function parseTimeSeconds(value: string): number {
+  const parts = value.split(':').map((p) => Number(p.trim()));
+  if (parts.some((n) => Number.isNaN(n))) {
+    return Number.NaN;
+  }
+  return parts.reduce((acc, n) => acc * 60 + n, 0);
+}
+
+/** Parses a "D mon YYYY" Polish date (e.g. "6 mar 2026") into a timestamp. */
+function parseResultDate(value: string): number {
+  const match = /^(\d{1,2})\s+([^\s]+)\s+(\d{4})$/.exec(value.trim());
+  if (!match) {
+    const fallback = Date.parse(value);
+    return Number.isNaN(fallback) ? Number.NaN : fallback;
+  }
+  const day = Number(match[1]);
+  const month = PL_MONTHS[match[2].toLowerCase()];
+  const year = Number(match[3]);
+  if (month === undefined) {
+    return Number.NaN;
+  }
+  return new Date(year, month, day).getTime();
+}
+
 interface QuizDetailProps {
   quizzes: QuizInfo[];
   selectedQuizId?: string | null;
@@ -138,9 +180,9 @@ export default function QuizDetail({
       } else if (sortKey === 'name') {
         cmp = a.name.localeCompare(b.name, 'pl');
       } else if (sortKey === 'time') {
-        cmp = a.time.localeCompare(b.time);
+        cmp = parseTimeSeconds(a.time) - parseTimeSeconds(b.time);
       } else if (sortKey === 'date') {
-        cmp = a.date.localeCompare(b.date);
+        cmp = parseResultDate(a.date) - parseResultDate(b.date);
       }
       return sortDir === 'asc' ? cmp : -cmp;
     });

--- a/frontend/app/components/admin/dashboard/QuizDetail.tsx
+++ b/frontend/app/components/admin/dashboard/QuizDetail.tsx
@@ -1,7 +1,9 @@
 'use client';
-
 import {
   Calendar,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronUp,
   Download,
   Eye,
   List,
@@ -10,7 +12,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import StatusBadge from '@/app/components/common/StatusBadge';
 import type { QuizInfo, ResultRow } from '@/app/types';
@@ -26,6 +28,9 @@ import {
   adminBlueHeadTableTheadClass,
   statusColors,
 } from '../shared/constants';
+
+type SortKey = 'name' | 'score' | 'time' | 'date';
+type SortDir = 'asc' | 'desc';
 
 interface QuizDetailProps {
   quizzes: QuizInfo[];
@@ -121,6 +126,44 @@ export default function QuizDetail({
     },
     [router, adminBase, onQuizDeleted],
   );
+
+  const [sortKey, setSortKey] = useState<SortKey>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const sortedResults = useMemo(() => {
+    return [...resultsForQuiz].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'score') {
+        cmp = a.score - b.score;
+      } else if (sortKey === 'name') {
+        cmp = a.name.localeCompare(b.name, 'pl');
+      } else if (sortKey === 'time') {
+        cmp = a.time.localeCompare(b.time);
+      } else if (sortKey === 'date') {
+        cmp = a.date.localeCompare(b.date);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [resultsForQuiz, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'score' ? 'desc' : 'asc');
+    }
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col)
+      return <ChevronsUpDown size={13} className="opacity-50" />;
+    return sortDir === 'asc' ? (
+      <ChevronUp size={13} />
+    ) : (
+      <ChevronDown size={13} />
+    );
+  }
 
   return (
     <AdminLayout
@@ -235,14 +278,29 @@ export default function QuizDetail({
             <table className={adminBlueHeadTableClass}>
               <thead className={adminBlueHeadTableTheadClass}>
                 <tr>
-                  <th className={adminBlueHeadTableThClass}>Imię</th>
-                  <th className={adminBlueHeadTableThClass}>Wynik</th>
-                  <th className={adminBlueHeadTableThClass}>Czas</th>
-                  <th className={adminBlueHeadTableThClass}>Data</th>
+                  {(
+                    [
+                      { key: 'name', label: 'Imię' },
+                      { key: 'score', label: 'Wynik' },
+                      { key: 'time', label: 'Czas' },
+                      { key: 'date', label: 'Data' },
+                    ] as { key: SortKey; label: string }[]
+                  ).map(({ key, label }) => (
+                    <th key={key} className={adminBlueHeadTableThClass}>
+                      <button
+                        type="button"
+                        onClick={() => handleSort(key)}
+                        className="flex cursor-pointer items-center gap-1 hover:opacity-80"
+                      >
+                        {label}
+                        <SortIcon col={key} />
+                      </button>
+                    </th>
+                  ))}
                 </tr>
               </thead>
               <tbody>
-                {resultsForQuiz.length === 0 ? (
+                {sortedResults.length === 0 ? (
                   <tr>
                     <td
                       colSpan={4}
@@ -252,7 +310,7 @@ export default function QuizDetail({
                     </td>
                   </tr>
                 ) : (
-                  resultsForQuiz.map((row, index) => (
+                  sortedResults.map((row, index) => (
                     <tr
                       key={`${row.name}-${index}`}
                       className="border-t border-[var(--border)]"

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -3,9 +3,6 @@
 import {
   ArrowLeft,
   Ban,
-  ChevronDown,
-  ChevronsUpDown,
-  ChevronUp,
   CircleStop,
   Download,
   ExternalLink,
@@ -24,6 +21,8 @@ import {
   adminDangerOutlineButtonClass,
   adminToolbarButtonClass,
 } from '@/app/components/admin/shared/constants';
+import { SortableTh } from '@/app/components/common/SortableTh';
+import { useSortableColumns } from '@/hooks/useSortableColumns';
 import { formatAdminDate } from '@/lib/admin-date-time';
 import {
   activateQuiz,
@@ -34,7 +33,12 @@ import {
 
 type Snapshot = Awaited<ReturnType<typeof getSessionSnapshot>>;
 type SortKey = 'nickname' | 'status' | 'score';
-type SortDir = 'asc' | 'desc';
+
+const SORT_COLUMNS = [
+  { key: 'nickname', label: 'Pseudonim' },
+  { key: 'status', label: 'Stan' },
+  { key: 'score', label: 'Wynik (zdobyte / maks.)' },
+] satisfies { key: SortKey; label: string }[];
 
 function statusOrder(p: { blocked: boolean; has_submitted: boolean }): number {
   if (p.blocked) return 0;
@@ -114,42 +118,22 @@ export function RunningQuizView({
   } | null>(null);
   const [snap, setSnap] = useState<Snapshot | null>(null);
   const [err, setErr] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('score');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const sort = useSortableColumns<SortKey>({ initialKey: 'score' });
 
   const sortedParticipants = useMemo(() => {
     const list = snap?.participants ?? [];
     return [...list].sort((a, b) => {
       let cmp = 0;
-      if (sortKey === 'score') {
+      if (sort.sortKey === 'score') {
         cmp = (a.score ?? -1) - (b.score ?? -1);
-      } else if (sortKey === 'nickname') {
+      } else if (sort.sortKey === 'nickname') {
         cmp = a.nickname.localeCompare(b.nickname, 'pl');
       } else {
         cmp = statusOrder(a) - statusOrder(b);
       }
-      return sortDir === 'asc' ? cmp : -cmp;
+      return sort.sortDir === 'asc' ? cmp : -cmp;
     });
-  }, [snap, sortKey, sortDir]);
-
-  function handleSort(key: SortKey) {
-    if (sortKey === key) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortKey(key);
-      setSortDir(key === 'score' ? 'desc' : 'asc');
-    }
-  }
-
-  function SortIcon({ col }: { col: SortKey }) {
-    if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
-    return sortDir === 'asc' ? (
-      <ChevronUp size={13} aria-hidden />
-    ) : (
-      <ChevronDown size={13} aria-hidden />
-    );
-  }
+  }, [snap, sort.sortKey, sort.sortDir]);
 
   const buildPresenterUrl = () => {
     if (!activation) {
@@ -433,33 +417,14 @@ export function RunningQuizView({
           <table className={adminBlueHeadTableClass}>
             <thead className={adminBlueHeadTableTheadClass}>
               <tr>
-                {(
-                  [
-                    { key: 'nickname', label: 'Pseudonim' },
-                    { key: 'status', label: 'Stan' },
-                    { key: 'score', label: 'Wynik (zdobyte / maks.)' },
-                  ] as { key: SortKey; label: string }[]
-                ).map(({ key, label }) => (
-                  <th
+                {SORT_COLUMNS.map(({ key, label }) => (
+                  <SortableTh
                     key={key}
-                    aria-sort={
-                      sortKey === key
-                        ? sortDir === 'asc'
-                          ? 'ascending'
-                          : 'descending'
-                        : 'none'
-                    }
+                    columnKey={key}
+                    label={label}
+                    sort={sort}
                     className={adminBlueHeadTableThClass}
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handleSort(key)}
-                      className="flex cursor-pointer items-center gap-1 hover:opacity-80"
-                    >
-                      {label}
-                      <SortIcon col={key} />
-                    </button>
-                  </th>
+                  />
                 ))}
                 <th className={adminBlueHeadTableThClass}>Akcje</th>
               </tr>

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -143,11 +143,11 @@ export function RunningQuizView({
 
   function SortIcon({ col }: { col: SortKey }) {
     if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" />;
+      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
     return sortDir === 'asc' ? (
-      <ChevronUp size={13} />
+      <ChevronUp size={13} aria-hidden />
     ) : (
-      <ChevronDown size={13} />
+      <ChevronDown size={13} aria-hidden />
     );
   }
 
@@ -440,7 +440,17 @@ export function RunningQuizView({
                     { key: 'score', label: 'Wynik (zdobyte / maks.)' },
                   ] as { key: SortKey; label: string }[]
                 ).map(({ key, label }) => (
-                  <th key={key} className={adminBlueHeadTableThClass}>
+                  <th
+                    key={key}
+                    aria-sort={
+                      sortKey === key
+                        ? sortDir === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                    }
+                    className={adminBlueHeadTableThClass}
+                  >
                     <button
                       type="button"
                       onClick={() => handleSort(key)}

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -3,12 +3,15 @@
 import {
   ArrowLeft,
   Ban,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronUp,
   CircleStop,
   Download,
   ExternalLink,
   RefreshCcw,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { QrCode } from '@/app/components/admin/dashboard/QrCode';
 import AdminLayout from '@/app/components/admin/layout/AdminLayout';
@@ -30,6 +33,14 @@ import {
 } from '@/lib/sessions/client';
 
 type Snapshot = Awaited<ReturnType<typeof getSessionSnapshot>>;
+type SortKey = 'nickname' | 'status' | 'score';
+type SortDir = 'asc' | 'desc';
+
+function statusOrder(p: { blocked: boolean; has_submitted: boolean }): number {
+  if (p.blocked) return 0;
+  if (p.has_submitted) return 2;
+  return 1;
+}
 
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -103,6 +114,42 @@ export function RunningQuizView({
   } | null>(null);
   const [snap, setSnap] = useState<Snapshot | null>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const sortedParticipants = useMemo(() => {
+    const list = snap?.participants ?? [];
+    return [...list].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'score') {
+        cmp = (a.score ?? -1) - (b.score ?? -1);
+      } else if (sortKey === 'nickname') {
+        cmp = a.nickname.localeCompare(b.nickname, 'pl');
+      } else {
+        cmp = statusOrder(a) - statusOrder(b);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [snap, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'score' ? 'desc' : 'asc');
+    }
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col)
+      return <ChevronsUpDown size={13} className="opacity-50" />;
+    return sortDir === 'asc' ? (
+      <ChevronUp size={13} />
+    ) : (
+      <ChevronDown size={13} />
+    );
+  }
 
   const buildPresenterUrl = () => {
     if (!activation) {
@@ -386,16 +433,29 @@ export function RunningQuizView({
           <table className={adminBlueHeadTableClass}>
             <thead className={adminBlueHeadTableTheadClass}>
               <tr>
-                <th className={adminBlueHeadTableThClass}>Pseudonim</th>
-                <th className={adminBlueHeadTableThClass}>Stan</th>
-                <th className={adminBlueHeadTableThClass}>
-                  Wynik (zdobyte / maks.)
-                </th>
+                {(
+                  [
+                    { key: 'nickname', label: 'Pseudonim' },
+                    { key: 'status', label: 'Stan' },
+                    { key: 'score', label: 'Wynik (zdobyte / maks.)' },
+                  ] as { key: SortKey; label: string }[]
+                ).map(({ key, label }) => (
+                  <th key={key} className={adminBlueHeadTableThClass}>
+                    <button
+                      type="button"
+                      onClick={() => handleSort(key)}
+                      className="flex cursor-pointer items-center gap-1 hover:opacity-80"
+                    >
+                      {label}
+                      <SortIcon col={key} />
+                    </button>
+                  </th>
+                ))}
                 <th className={adminBlueHeadTableThClass}>Akcje</th>
               </tr>
             </thead>
             <tbody>
-              {(snap?.participants ?? []).length === 0 ? (
+              {sortedParticipants.length === 0 ? (
                 <tr>
                   <td
                     colSpan={4}
@@ -405,7 +465,7 @@ export function RunningQuizView({
                   </td>
                 </tr>
               ) : (
-                (snap?.participants ?? []).map((p) => (
+                sortedParticipants.map((p) => (
                   <tr
                     key={p.nickname}
                     className="border-t border-[var(--border)]"

--- a/frontend/app/components/admin/results/ResultDetailView.tsx
+++ b/frontend/app/components/admin/results/ResultDetailView.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { ArrowLeft, List, RefreshCcw, Trash2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronDown,
+  ChevronsUpDown,
+  ChevronUp,
+  List,
+  RefreshCcw,
+  Trash2,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -18,6 +26,9 @@ import {
   resultFileDisplayName,
 } from '@/lib/results/archivePayload';
 import { deleteResult, readResult } from '@/lib/results/client';
+
+type SortKey = 'nickname' | 'score' | 'submitted_at';
+type SortDir = 'asc' | 'desc';
 
 type Props = {
   adminBase: string;
@@ -42,6 +53,8 @@ export function ResultDetailView({
 }: Props) {
   const [payload, setPayload] = useState<unknown>(null);
   const [err, setErr] = useState<string | null>(null);
+  const [sortKey, setSortKey] = useState<SortKey>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
 
   /* Clear stale archive UI before each date/file fetch. */
   /* eslint-disable react-hooks/set-state-in-effect -- reset payload/err when inputs change */
@@ -76,6 +89,40 @@ export function ResultDetailView({
     const r = resultArchivePayloadSchema.safeParse(payload);
     return r.success ? r.data : null;
   }, [payload]);
+
+  const sortedScores = useMemo(() => {
+    if (!parsed) return [];
+    return [...parsed.scores].sort((a, b) => {
+      let cmp = 0;
+      if (sortKey === 'score') {
+        cmp = a.score - b.score;
+      } else if (sortKey === 'nickname') {
+        cmp = a.nickname.localeCompare(b.nickname, 'pl');
+      } else {
+        cmp = a.submitted_at.localeCompare(b.submitted_at);
+      }
+      return sortDir === 'asc' ? cmp : -cmp;
+    });
+  }, [parsed, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'score' ? 'desc' : 'asc');
+    }
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col)
+      return <ChevronsUpDown size={13} className="opacity-50" />;
+    return sortDir === 'asc' ? (
+      <ChevronUp size={13} />
+    ) : (
+      <ChevronDown size={13} />
+    );
+  }
 
   const fileTitle = resultFileDisplayName(file);
 
@@ -193,19 +240,31 @@ export function ResultDetailView({
               <table className="w-full min-w-[320px] text-left text-sm">
                 <thead className="border-b border-[var(--border)] bg-[var(--page-bg)]">
                   <tr>
-                    <th className="px-4 py-3 font-semibold text-[var(--text-dark)]">
-                      Pseudonim
-                    </th>
-                    <th className="px-4 py-3 font-semibold text-[var(--text-dark)]">
-                      Wynik (zdobyte / maks.)
-                    </th>
-                    <th className="px-4 py-3 font-semibold text-[var(--text-dark)]">
-                      Wysłano
-                    </th>
+                    {(
+                      [
+                        { key: 'nickname', label: 'Pseudonim' },
+                        { key: 'score', label: 'Wynik (zdobyte / maks.)' },
+                        { key: 'submitted_at', label: 'Wysłano' },
+                      ] as { key: SortKey; label: string }[]
+                    ).map(({ key, label }) => (
+                      <th
+                        key={key}
+                        className="px-4 py-3 font-semibold text-[var(--text-dark)]"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => handleSort(key)}
+                          className="flex cursor-pointer items-center gap-1 hover:opacity-70"
+                        >
+                          {label}
+                          <SortIcon col={key} />
+                        </button>
+                      </th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>
-                  {parsed.scores.map((row) => (
+                  {sortedScores.map((row) => (
                     <tr
                       key={`${row.nickname}-${row.submitted_at}`}
                       className="border-t border-[var(--border)]"

--- a/frontend/app/components/admin/results/ResultDetailView.tsx
+++ b/frontend/app/components/admin/results/ResultDetailView.tsx
@@ -1,14 +1,6 @@
 'use client';
 
-import {
-  ArrowLeft,
-  ChevronDown,
-  ChevronsUpDown,
-  ChevronUp,
-  List,
-  RefreshCcw,
-  Trash2,
-} from 'lucide-react';
+import { ArrowLeft, List, RefreshCcw, Trash2 } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -18,6 +10,8 @@ import {
   adminPrimaryOutlineButtonClass,
   adminToolbarButtonClass,
 } from '@/app/components/admin/shared/constants';
+import { SortableTh } from '@/app/components/common/SortableTh';
+import { useSortableColumns } from '@/hooks/useSortableColumns';
 import { formatAdminDate } from '@/lib/admin-date-time';
 import {
   formatArchivedScore,
@@ -28,7 +22,12 @@ import {
 import { deleteResult, readResult } from '@/lib/results/client';
 
 type SortKey = 'nickname' | 'score' | 'submitted_at';
-type SortDir = 'asc' | 'desc';
+
+const SORT_COLUMNS = [
+  { key: 'nickname', label: 'Pseudonim' },
+  { key: 'score', label: 'Wynik (zdobyte / maks.)' },
+  { key: 'submitted_at', label: 'Wysłano' },
+] satisfies { key: SortKey; label: string }[];
 
 type Props = {
   adminBase: string;
@@ -53,8 +52,7 @@ export function ResultDetailView({
 }: Props) {
   const [payload, setPayload] = useState<unknown>(null);
   const [err, setErr] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('score');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const sort = useSortableColumns<SortKey>({ initialKey: 'score' });
 
   /* Clear stale archive UI before each date/file fetch. */
   /* eslint-disable react-hooks/set-state-in-effect -- reset payload/err when inputs change */
@@ -94,35 +92,16 @@ export function ResultDetailView({
     if (!parsed) return [];
     return [...parsed.scores].sort((a, b) => {
       let cmp = 0;
-      if (sortKey === 'score') {
+      if (sort.sortKey === 'score') {
         cmp = a.score - b.score;
-      } else if (sortKey === 'nickname') {
+      } else if (sort.sortKey === 'nickname') {
         cmp = a.nickname.localeCompare(b.nickname, 'pl');
       } else {
         cmp = a.submitted_at.localeCompare(b.submitted_at);
       }
-      return sortDir === 'asc' ? cmp : -cmp;
+      return sort.sortDir === 'asc' ? cmp : -cmp;
     });
-  }, [parsed, sortKey, sortDir]);
-
-  function handleSort(key: SortKey) {
-    if (sortKey === key) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortKey(key);
-      setSortDir(key === 'score' ? 'desc' : 'asc');
-    }
-  }
-
-  function SortIcon({ col }: { col: SortKey }) {
-    if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
-    return sortDir === 'asc' ? (
-      <ChevronUp size={13} aria-hidden />
-    ) : (
-      <ChevronDown size={13} aria-hidden />
-    );
-  }
+  }, [parsed, sort.sortKey, sort.sortDir]);
 
   const fileTitle = resultFileDisplayName(file);
 
@@ -240,33 +219,14 @@ export function ResultDetailView({
               <table className="w-full min-w-[320px] text-left text-sm">
                 <thead className="border-b border-[var(--border)] bg-[var(--page-bg)]">
                   <tr>
-                    {(
-                      [
-                        { key: 'nickname', label: 'Pseudonim' },
-                        { key: 'score', label: 'Wynik (zdobyte / maks.)' },
-                        { key: 'submitted_at', label: 'Wysłano' },
-                      ] as { key: SortKey; label: string }[]
-                    ).map(({ key, label }) => (
-                      <th
+                    {SORT_COLUMNS.map(({ key, label }) => (
+                      <SortableTh
                         key={key}
-                        aria-sort={
-                          sortKey === key
-                            ? sortDir === 'asc'
-                              ? 'ascending'
-                              : 'descending'
-                            : 'none'
-                        }
+                        columnKey={key}
+                        label={label}
+                        sort={sort}
                         className="px-4 py-3 font-semibold text-[var(--text-dark)]"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => handleSort(key)}
-                          className="flex cursor-pointer items-center gap-1 hover:opacity-70"
-                        >
-                          {label}
-                          <SortIcon col={key} />
-                        </button>
-                      </th>
+                      />
                     ))}
                   </tr>
                 </thead>

--- a/frontend/app/components/admin/results/ResultDetailView.tsx
+++ b/frontend/app/components/admin/results/ResultDetailView.tsx
@@ -116,11 +116,11 @@ export function ResultDetailView({
 
   function SortIcon({ col }: { col: SortKey }) {
     if (sortKey !== col)
-      return <ChevronsUpDown size={13} className="opacity-50" />;
+      return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
     return sortDir === 'asc' ? (
-      <ChevronUp size={13} />
+      <ChevronUp size={13} aria-hidden />
     ) : (
-      <ChevronDown size={13} />
+      <ChevronDown size={13} aria-hidden />
     );
   }
 
@@ -249,6 +249,13 @@ export function ResultDetailView({
                     ).map(({ key, label }) => (
                       <th
                         key={key}
+                        aria-sort={
+                          sortKey === key
+                            ? sortDir === 'asc'
+                              ? 'ascending'
+                              : 'descending'
+                            : 'none'
+                        }
                         className="px-4 py-3 font-semibold text-[var(--text-dark)]"
                       >
                         <button

--- a/frontend/app/components/admin/results/ResultsBrowserView.tsx
+++ b/frontend/app/components/admin/results/ResultsBrowserView.tsx
@@ -46,6 +46,7 @@ export function ResultsBrowserView({
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };

--- a/frontend/app/components/common/SortableTh.tsx
+++ b/frontend/app/components/common/SortableTh.tsx
@@ -1,0 +1,46 @@
+import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
+
+import type { SortableColumns, SortDir } from '@/hooks/useSortableColumns';
+
+/** Direction indicator shown next to a sortable column label. */
+export function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) {
+    return <ChevronsUpDown size={13} className="opacity-50" aria-hidden />;
+  }
+  return dir === 'asc' ? (
+    <ChevronUp size={13} aria-hidden />
+  ) : (
+    <ChevronDown size={13} aria-hidden />
+  );
+}
+
+interface SortableThProps<K extends string> {
+  /** Column this header sorts by. */
+  columnKey: K;
+  label: string;
+  sort: SortableColumns<K>;
+  /** Classes for the `<th>` element (table-specific styling). */
+  className?: string;
+}
+
+/** A table header cell whose label is a button that sorts the table by `columnKey`. */
+export function SortableTh<K extends string>({
+  columnKey,
+  label,
+  sort,
+  className,
+}: SortableThProps<K>) {
+  const active = sort.sortKey === columnKey;
+  return (
+    <th aria-sort={sort.getAriaSort(columnKey)} className={className}>
+      <button
+        type="button"
+        onClick={() => sort.handleSort(columnKey)}
+        className="flex cursor-pointer items-center gap-1 hover:opacity-80"
+      >
+        {label}
+        <SortIcon active={active} dir={sort.sortDir} />
+      </button>
+    </th>
+  );
+}

--- a/frontend/app/components/common/index.ts
+++ b/frontend/app/components/common/index.ts
@@ -1,5 +1,6 @@
 export { default as ImageDropzone } from './ImageDropzone';
 export { default as ProgressBar } from './ProgressBar';
 export { default as SliderTrack } from './SliderTrack';
+export { SortableTh, SortIcon } from './SortableTh';
 export { default as StatusBadge } from './StatusBadge';
 export { default as SubmitButton } from './SubmitButton';

--- a/frontend/app/components/quiz/results/QuizResults.tsx
+++ b/frontend/app/components/quiz/results/QuizResults.tsx
@@ -94,7 +94,7 @@ export default function QuizResults({
             <div className="h-px bg-[var(--border)]" />
             {sortedRanking.map((entry, idx) => (
               <RankingRow
-                key={entry.position}
+                key={`${entry.name}-${entry.score}`}
                 entry={entry}
                 isLast={idx === sortedRanking.length - 1}
               />

--- a/frontend/app/components/quiz/results/QuizResults.tsx
+++ b/frontend/app/components/quiz/results/QuizResults.tsx
@@ -37,7 +37,18 @@ export default function QuizResults({
     if (!ranking) return [];
     return [...ranking]
       .sort((a, b) => parseScore(b.score) - parseScore(a.score))
-      .map((entry, idx) => ({ ...entry, position: idx + 1 }));
+      .map((entry, idx) => ({
+        ...entry,
+        position: idx + 1,
+        medal:
+          idx === 0
+            ? ('gold' as const)
+            : idx === 1
+              ? ('silver' as const)
+              : idx === 2
+                ? ('bronze' as const)
+                : undefined,
+      }));
   }, [ranking]);
 
   return (

--- a/frontend/app/components/quiz/results/QuizResults.tsx
+++ b/frontend/app/components/quiz/results/QuizResults.tsx
@@ -94,7 +94,7 @@ export default function QuizResults({
             <div className="h-px bg-[var(--border)]" />
             {sortedRanking.map((entry, idx) => (
               <RankingRow
-                key={`${entry.name}-${entry.score}`}
+                key={entry.position}
                 entry={entry}
                 isLast={idx === sortedRanking.length - 1}
               />

--- a/frontend/app/components/quiz/results/QuizResults.tsx
+++ b/frontend/app/components/quiz/results/QuizResults.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FileCheck, RotateCcw } from 'lucide-react';
+import { useMemo } from 'react';
 
 import type { RankingEntry } from '@/app/types';
 
@@ -18,6 +19,10 @@ interface QuizResultsProps {
   onReview?: () => void;
 }
 
+function parseScore(score: string): number {
+  return parseFloat(score.replace('%', '')) || 0;
+}
+
 export default function QuizResults({
   scorePercent,
   scorePoints,
@@ -28,6 +33,13 @@ export default function QuizResults({
   onRetry,
   onReview,
 }: QuizResultsProps) {
+  const sortedRanking = useMemo(() => {
+    if (!ranking) return [];
+    return [...ranking]
+      .sort((a, b) => parseScore(b.score) - parseScore(a.score))
+      .map((entry, idx) => ({ ...entry, position: idx + 1 }));
+  }, [ranking]);
+
   return (
     <div className="flex h-full w-full flex-col bg-[var(--page-bg)]">
       <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 pt-4 pb-8">
@@ -61,7 +73,7 @@ export default function QuizResults({
           </div>
         </section>
 
-        {ranking && ranking.length > 0 && (
+        {sortedRanking.length > 0 && (
           <section className="overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card-bg)]">
             <div className="px-4 py-3.5">
               <h2 className="text-[15px] font-bold text-[var(--text-dark)]">
@@ -69,11 +81,11 @@ export default function QuizResults({
               </h2>
             </div>
             <div className="h-px bg-[var(--border)]" />
-            {ranking.map((entry, idx) => (
+            {sortedRanking.map((entry, idx) => (
               <RankingRow
                 key={entry.position}
                 entry={entry}
-                isLast={idx === ranking.length - 1}
+                isLast={idx === sortedRanking.length - 1}
               />
             ))}
           </section>

--- a/frontend/hooks/useSortableColumns.ts
+++ b/frontend/hooks/useSortableColumns.ts
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+
+export type SortDir = 'asc' | 'desc';
+
+export type AriaSort = 'ascending' | 'descending' | 'none';
+
+export interface UseSortableColumnsOptions<K extends string> {
+  /** Column key selected on first render. */
+  initialKey: K;
+  /** Sort direction on first render. Defaults to 'desc'. */
+  initialDir?: SortDir;
+  /**
+   * Keys that start descending the first time they are selected (e.g. score
+   * columns, where "highest first" is the natural default). Defaults to the
+   * initial key.
+   */
+  descFirstKeys?: readonly K[];
+}
+
+export interface SortableColumns<K extends string> {
+  sortKey: K;
+  sortDir: SortDir;
+  /** Toggles direction when the active column is reselected, otherwise switches column. */
+  handleSort: (key: K) => void;
+  /** aria-sort value for a column header `<th>`. */
+  getAriaSort: (key: K) => AriaSort;
+}
+
+/**
+ * Shared sortable-table-header state: tracks the active column and direction,
+ * and provides the click handler + aria-sort helper used by `SortableTh`.
+ */
+export function useSortableColumns<K extends string>({
+  initialKey,
+  initialDir = 'desc',
+  descFirstKeys = [initialKey],
+}: UseSortableColumnsOptions<K>): SortableColumns<K> {
+  const [sortKey, setSortKey] = useState<K>(initialKey);
+  const [sortDir, setSortDir] = useState<SortDir>(initialDir);
+
+  function handleSort(key: K) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(descFirstKeys.includes(key) ? 'desc' : 'asc');
+    }
+  }
+
+  function getAriaSort(key: K): AriaSort {
+    if (key !== sortKey) return 'none';
+    return sortDir === 'asc' ? 'ascending' : 'descending';
+  }
+
+  return { sortKey, sortDir, handleSort, getAriaSort };
+}

--- a/frontend/lib/admin-result-sort.test.ts
+++ b/frontend/lib/admin-result-sort.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { parseResultDate, parseTimeSeconds } from './admin-result-sort';
+
+test('parseTimeSeconds parses M:SS / MM:SS / H:MM:SS', () => {
+  assert.equal(parseTimeSeconds('4:32'), 4 * 60 + 32);
+  assert.equal(parseTimeSeconds('12:05'), 12 * 60 + 5);
+  assert.equal(parseTimeSeconds('1:02:03'), 1 * 3600 + 2 * 60 + 3);
+});
+
+test('parseTimeSeconds tolerates surrounding whitespace', () => {
+  assert.equal(parseTimeSeconds(' 0:09 '), 9);
+});
+
+test('parseTimeSeconds returns NaN for non-numeric segments', () => {
+  assert.ok(Number.isNaN(parseTimeSeconds('abc')));
+  assert.ok(Number.isNaN(parseTimeSeconds('1:xx')));
+});
+
+test('parseTimeSeconds orders durations correctly', () => {
+  assert.ok(parseTimeSeconds('4:32') < parseTimeSeconds('5:01'));
+  assert.ok(parseTimeSeconds('59:59') < parseTimeSeconds('1:00:00'));
+});
+
+test('parseResultDate parses "D mon YYYY" Polish dates', () => {
+  assert.equal(parseResultDate('12 mar 2026'), new Date(2026, 2, 12).getTime());
+  assert.equal(parseResultDate('6 mar 2026'), new Date(2026, 2, 6).getTime());
+});
+
+test('parseResultDate is case-insensitive and accepts the "paz" alias', () => {
+  const expected = new Date(2026, 9, 3).getTime();
+  assert.equal(parseResultDate('3 Paź 2026'), expected);
+  assert.equal(parseResultDate('3 paz 2026'), expected);
+});
+
+test('parseResultDate orders dates chronologically', () => {
+  assert.ok(parseResultDate('6 mar 2026') < parseResultDate('12 mar 2026'));
+  assert.ok(parseResultDate('28 lut 2026') < parseResultDate('1 mar 2026'));
+});
+
+test('parseResultDate returns NaN for an unknown month', () => {
+  assert.ok(Number.isNaN(parseResultDate('12 xyz 2026')));
+});
+
+test('parseResultDate returns NaN for an overflowed (impossible) date', () => {
+  // 31 April does not exist; Date would silently normalize it to 1 May.
+  assert.ok(Number.isNaN(parseResultDate('31 kwi 2026')));
+});
+
+test('parseResultDate falls back to Date.parse for ISO-like input', () => {
+  assert.equal(parseResultDate('2026-03-12'), Date.parse('2026-03-12'));
+});
+
+test('parseResultDate returns NaN for unparseable input', () => {
+  assert.ok(Number.isNaN(parseResultDate('not a date')));
+});

--- a/frontend/lib/admin-result-sort.ts
+++ b/frontend/lib/admin-result-sort.ts
@@ -1,0 +1,58 @@
+/**
+ * Parsers that turn the pre-formatted Polish date/time strings shown in the
+ * demo result rows back into sortable numbers. The demo `ResultRow` only
+ * carries display strings (e.g. "4:32", "12 mar 2026"), so sorting has to
+ * re-derive a numeric key from them. Invalid input returns NaN, which callers
+ * sort last.
+ */
+
+/** Polish month abbreviations used in the demo result rows (e.g. "12 mar 2026"). */
+const PL_MONTHS: Record<string, number> = {
+  sty: 0,
+  lut: 1,
+  mar: 2,
+  kwi: 3,
+  maj: 4,
+  cze: 5,
+  lip: 6,
+  sie: 7,
+  wrz: 8,
+  paź: 9,
+  paz: 9,
+  lis: 10,
+  gru: 11,
+};
+
+/** Parses a "M:SS" / "MM:SS" / "H:MM:SS" duration into total seconds. */
+export function parseTimeSeconds(value: string): number {
+  const parts = value.split(':').map((p) => Number(p.trim()));
+  if (parts.some((n) => Number.isNaN(n))) {
+    return Number.NaN;
+  }
+  return parts.reduce((acc, n) => acc * 60 + n, 0);
+}
+
+/** Parses a "D mon YYYY" Polish date (e.g. "6 mar 2026") into a timestamp. */
+export function parseResultDate(value: string): number {
+  const match = /^(\d{1,2})\s+([^\s]+)\s+(\d{4})$/.exec(value.trim());
+  if (!match) {
+    const fallback = Date.parse(value);
+    return Number.isNaN(fallback) ? Number.NaN : fallback;
+  }
+  const day = Number(match[1]);
+  const month = PL_MONTHS[match[2].toLowerCase()];
+  const year = Number(match[3]);
+  if (month === undefined) {
+    return Number.NaN;
+  }
+  const date = new Date(year, month, day);
+  // Reject overflowed dates (e.g. "31 kwi") that Date silently normalizes.
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month ||
+    date.getDate() !== day
+  ) {
+    return Number.NaN;
+  }
+  return date.getTime();
+}


### PR DESCRIPTION
added leaderboards sorting both in running quiz and quiz detail views. Fixed bug preventing results from correctly loading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin tables and result/detail views gain clickable, visual sortable headers and shared sortable-column behavior.
  * Ranking display now computes positions and awards top‑3 medals.

* **Improvements**
  * Robust mounted-state handling to avoid stale updates.
  * Locale-aware nickname sorting and consistent ordering for scores, times, dates, and participant status.

* **Tests**
  * Added unit tests for time/date parsing used for result sorting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->