### PR TITLE
[RDE-79] feat(editor): slider extreme labels

### DIFF
--- a/backend/schemas/admin_quiz.py
+++ b/backend/schemas/admin_quiz.py
@@ -114,6 +114,8 @@ class AdminQuizSliderPayload(_AdminQuizPayloadBase):
     step: float = 1
     tolerance: float = 0
     unit: str | None = None
+    min_label: str | None = None
+    max_label: str | None = None
 
     @model_validator(mode="after")
     def _validate(self) -> AdminQuizSliderPayload:

--- a/backend/schemas/kqf.py
+++ b/backend/schemas/kqf.py
@@ -91,6 +91,9 @@ class KqfSlider(_KqfBaseQuestion):
     step: float = 1
     tolerance: float = 0
     unit: str | None = None
+    # Optional labels describing the slider extremes (e.g. what min and max mean).
+    min_label: str | None = None
+    max_label: str | None = None
 
     @model_validator(mode="after")
     def _validate_range(self) -> KqfSlider:

--- a/backend/services/admin_quiz_adapters.py
+++ b/backend/services/admin_quiz_adapters.py
@@ -83,6 +83,8 @@ def upsert_payload_to_kqf(
                     step=q.step,
                     tolerance=q.tolerance,
                     unit=q.unit,
+                    min_label=q.min_label,
+                    max_label=q.max_label,
                     **common,
                 )
             )
@@ -157,6 +159,8 @@ def kqf_to_admin_detail_payload(
                     step=q.step,
                     tolerance=q.tolerance,
                     unit=q.unit,
+                    min_label=q.min_label,
+                    max_label=q.max_label,
                     **common,
                 )
             )

--- a/backend/services/kqf.py
+++ b/backend/services/kqf.py
@@ -55,7 +55,8 @@ _HEADER_RE = re.compile(
 _CHOICE_RE = re.compile(r"^-\s*\[(?P<mark>[ xX])\](?:\s+(?P<text>.+?))?\s*$")
 _DIRECTIVE_RE = re.compile(r"^@(?P<key>image|video|audio|hint):\s*(?P<value>.+?)\s*$")
 _SLIDER_FIELD_RE = re.compile(
-    r"^\s{2,}(?P<key>correct|min|max|step|tolerance|unit):\s*(?P<value>.+?)\s*$"
+    r"^\s{2,}(?P<key>correct|min_label|max_label|min|max|step|tolerance|unit):"
+    r"\s*(?P<value>.+?)\s*$"
 )
 
 
@@ -291,7 +292,11 @@ def _build_slider(
     if not fields:
         raise KqfParseError("slider question requires @slider: block", line=header_line)
     try:
-        kwargs: dict[str, object] = {"unit": fields.get("unit")}
+        kwargs: dict[str, object] = {
+            "unit": fields.get("unit"),
+            "min_label": fields.get("min_label"),
+            "max_label": fields.get("max_label"),
+        }
         for key in ("correct", "min", "max"):
             if key not in fields:
                 raise KqfParseError(
@@ -351,6 +356,10 @@ def _write_question(buf: io.StringIO, question: object) -> None:
             buf.write(f"  tolerance: {_fmt_num(question.tolerance)}\n")
         if question.unit:
             buf.write(f"  unit: {question.unit}\n")
+        if question.min_label:
+            buf.write(f"  min_label: {question.min_label}\n")
+        if question.max_label:
+            buf.write(f"  max_label: {question.max_label}\n")
 
     media_kwargs = question.media.model_dump(exclude_none=True)
     if media_kwargs:

--- a/backend/services/results.py
+++ b/backend/services/results.py
@@ -102,9 +102,7 @@ def list_results_in_day(paths: StoragePaths, date: str) -> list[ResultFileMetada
                     score_count=len(data.get("scores", [])),
                 )
             )
-        except json.JSONDecodeError:
-            continue
-        except OSError:
+        except json.JSONDecodeError, OSError:
             continue
     return out
 

--- a/backend/services/results.py
+++ b/backend/services/results.py
@@ -102,7 +102,7 @@ def list_results_in_day(paths: StoragePaths, date: str) -> list[ResultFileMetada
                     score_count=len(data.get("scores", [])),
                 )
             )
-        except json.JSONDecodeError, OSError:
+        except (json.JSONDecodeError, OSError):
             continue
     return out
 

--- a/backend/services/results.py
+++ b/backend/services/results.py
@@ -102,7 +102,9 @@ def list_results_in_day(paths: StoragePaths, date: str) -> list[ResultFileMetada
                     score_count=len(data.get("scores", [])),
                 )
             )
-        except (json.JSONDecodeError, OSError):
+        except json.JSONDecodeError:
+            continue
+        except OSError:
             continue
     return out
 

--- a/backend/tests/test_kqf_roundtrip.py
+++ b/backend/tests/test_kqf_roundtrip.py
@@ -73,3 +73,29 @@ def test_roundtrip_full_kqf_example() -> None:
         ],
     )
     _assert_roundtrip(quiz)
+
+
+def test_roundtrip_slider_with_extreme_labels() -> None:
+    quiz = KqfQuiz(
+        front_matter=KqfFrontMatter(title="Opinions"),
+        questions=[
+            KqfSlider(
+                id="Q1",
+                type="slider",
+                text="How much do you agree?",
+                correct=5,
+                min=1,
+                max=10,
+                step=1,
+                tolerance=2,
+                min_label="Zdecydowanie nie",
+                max_label="Zdecydowanie tak",
+            ),
+        ],
+    )
+    _assert_roundtrip(quiz)
+    parsed = parse_kqf(serialize_kqf(quiz))
+    slider = parsed.questions[0]
+    assert isinstance(slider, KqfSlider)
+    assert slider.min_label == "Zdecydowanie nie"
+    assert slider.max_label == "Zdecydowanie tak"

--- a/frontend/app/components/admin/editor/QuestionListItem.tsx
+++ b/frontend/app/components/admin/editor/QuestionListItem.tsx
@@ -390,6 +390,10 @@ function SliderSection({ questionIndex }: { questionIndex: number }) {
   const tolerance = Number(watch(`${questionPath}.tolerance` as const));
   const unitStr =
     (watch(`${questionPath}.unit` as const) as string | null)?.trim() ?? '';
+  const minLabelStr =
+    (watch(`${questionPath}.minLabel` as const) as string | null) ?? '';
+  const maxLabelStr =
+    (watch(`${questionPath}.maxLabel` as const) as string | null) ?? '';
 
   const safeStep = Number.isFinite(step) && step > 0 ? step : 1;
   const previewTicks = 5;
@@ -495,6 +499,45 @@ function SliderSection({ questionIndex }: { questionIndex: number }) {
         </label>
       </div>
 
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1">
+          <span className="text-[13px] font-medium text-[var(--text-muted)]">
+            Podpis wartości min (opcj.)
+          </span>
+          <input
+            value={minLabelStr}
+            placeholder={`Co oznacza ${Number.isFinite(min) ? min : 'min'}?`}
+            onChange={(event) => {
+              const v = event.target.value;
+              setValue(`${questionPath}.minLabel`, v.trim() ? v : null, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+              void trigger(questionPath);
+            }}
+            className="rounded-xl border border-[var(--border)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[13px] font-medium text-[var(--text-muted)]">
+            Podpis wartości max (opcj.)
+          </span>
+          <input
+            value={maxLabelStr}
+            placeholder={`Co oznacza ${Number.isFinite(max) ? max : 'max'}?`}
+            onChange={(event) => {
+              const v = event.target.value;
+              setValue(`${questionPath}.maxLabel`, v.trim() ? v : null, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+              void trigger(questionPath);
+            }}
+            className="rounded-xl border border-[var(--border)] bg-white px-3 py-2 text-sm"
+          />
+        </label>
+      </div>
+
       <div className="rounded-xl border border-dashed border-[var(--border)] bg-white px-3 py-2 text-xs text-[var(--text-muted)]">
         <span className="font-semibold text-[var(--text-dark)]">
           Podgląd zakresu:
@@ -538,6 +581,12 @@ function SliderSection({ questionIndex }: { questionIndex: number }) {
               />
             )}
           </div>
+          {(minLabelStr.trim() || maxLabelStr.trim()) && (
+            <div className="flex justify-between gap-2 text-xs font-medium text-[var(--text-muted)]">
+              <span className="truncate">{minLabelStr.trim()}</span>
+              <span className="truncate text-right">{maxLabelStr.trim()}</span>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/app/components/admin/editor/QuestionListItem.tsx
+++ b/frontend/app/components/admin/editor/QuestionListItem.tsx
@@ -583,8 +583,10 @@ function SliderSection({ questionIndex }: { questionIndex: number }) {
           </div>
           {(minLabelStr.trim() || maxLabelStr.trim()) && (
             <div className="flex justify-between gap-2 text-xs font-medium text-[var(--text-muted)]">
-              <span className="truncate">{minLabelStr.trim()}</span>
-              <span className="truncate text-right">{maxLabelStr.trim()}</span>
+              <span className="min-w-0 truncate">{minLabelStr.trim()}</span>
+              <span className="min-w-0 truncate text-right">
+                {maxLabelStr.trim()}
+              </span>
             </div>
           )}
         </div>

--- a/frontend/app/components/admin/editor/QuestionPreview.tsx
+++ b/frontend/app/components/admin/editor/QuestionPreview.tsx
@@ -72,7 +72,8 @@ function previewBody(
         </p>
       );
     case 'slider': {
-      const { min, max, step, correct, tolerance, unit } = question;
+      const { min, max, step, correct, tolerance, unit, minLabel, maxLabel } =
+        question;
       return (
         <div className="flex flex-col gap-1 text-sm text-[var(--text-dark)]">
           <p>
@@ -80,6 +81,13 @@ function previewBody(
             {unit ? ` ${unit}` : ''}, krok {step}
             {tolerance > 0 ? `, tolerancja ±${tolerance}` : ''}
           </p>
+          {(minLabel?.trim() || maxLabel?.trim()) && (
+            <p className="text-[var(--text-muted)]">
+              {minLabel?.trim() ? `${min}: ${minLabel.trim()}` : ''}
+              {minLabel?.trim() && maxLabel?.trim() ? ' · ' : ''}
+              {maxLabel?.trim() ? `${max}: ${maxLabel.trim()}` : ''}
+            </p>
+          )}
           <p className="font-semibold">Docelowo: {correct}</p>
         </div>
       );

--- a/frontend/app/components/quiz/questions/SliderQuestion.test.tsx
+++ b/frontend/app/components/quiz/questions/SliderQuestion.test.tsx
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+
+import SliderQuestion from '@/app/components/quiz/questions/SliderQuestion';
+
+test('renders the extreme labels when provided', () => {
+  const html = ReactDOMServer.renderToString(
+    <SliderQuestion
+      playInline
+      question="Jak bardzo się zgadzasz?"
+      min={1}
+      max={10}
+      defaultValue={5}
+      unit=""
+      ticks={[1, 5, 10]}
+      minLabel="Zdecydowanie nie"
+      maxLabel="Zdecydowanie tak"
+    />,
+  );
+  assert.match(html, /Zdecydowanie nie/);
+  assert.match(html, /Zdecydowanie tak/);
+});
+
+test('omits the label row when no labels are provided', () => {
+  const html = ReactDOMServer.renderToString(
+    <SliderQuestion
+      playInline
+      question="Q"
+      min={1}
+      max={10}
+      defaultValue={5}
+      unit=""
+      ticks={[1, 5, 10]}
+    />,
+  );
+  assert.doesNotMatch(html, /Zdecydowanie/);
+});

--- a/frontend/app/components/quiz/questions/SliderQuestion.tsx
+++ b/frontend/app/components/quiz/questions/SliderQuestion.tsx
@@ -94,8 +94,12 @@ function SliderBody({
 
         {(minLabel?.trim() || maxLabel?.trim()) && (
           <div className="mt-1 flex w-full justify-between gap-3 px-1 text-xs font-medium text-[var(--text-muted)]">
-            <span className="max-w-[45%] text-left">{minLabel?.trim()}</span>
-            <span className="max-w-[45%] text-right">{maxLabel?.trim()}</span>
+            <span className="max-w-[45%] min-w-0 truncate text-left">
+              {minLabel?.trim()}
+            </span>
+            <span className="max-w-[45%] min-w-0 truncate text-right">
+              {maxLabel?.trim()}
+            </span>
           </div>
         )}
       </div>

--- a/frontend/app/components/quiz/questions/SliderQuestion.tsx
+++ b/frontend/app/components/quiz/questions/SliderQuestion.tsx
@@ -23,6 +23,8 @@ interface SliderQuestionProps {
   defaultValue: number;
   unit: string;
   ticks: number[];
+  minLabel?: string | null;
+  maxLabel?: string | null;
   onSubmit?: (value: number) => void;
 }
 
@@ -34,6 +36,8 @@ function SliderBody({
   value,
   unit,
   ticks,
+  minLabel,
+  maxLabel,
   onChange,
 }: {
   question: string;
@@ -43,6 +47,8 @@ function SliderBody({
   value: number;
   unit: string;
   ticks: number[];
+  minLabel?: string | null;
+  maxLabel?: string | null;
   onChange: (v: number) => void;
 }) {
   const range = max - min;
@@ -85,6 +91,13 @@ function SliderBody({
             </span>
           ))}
         </div>
+
+        {(minLabel?.trim() || maxLabel?.trim()) && (
+          <div className="mt-1 flex w-full justify-between gap-3 px-1 text-xs font-medium text-[var(--text-muted)]">
+            <span className="max-w-[45%] text-left">{minLabel?.trim()}</span>
+            <span className="max-w-[45%] text-right">{maxLabel?.trim()}</span>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -103,6 +116,8 @@ export default function SliderQuestion({
   defaultValue,
   unit,
   ticks,
+  minLabel,
+  maxLabel,
   onSubmit,
 }: SliderQuestionProps) {
   const [value, setValue] = useState(defaultValue);
@@ -118,6 +133,8 @@ export default function SliderQuestion({
         value={value}
         unit={unit}
         ticks={ticks}
+        minLabel={minLabel}
+        maxLabel={maxLabel}
         onChange={setValue}
       />
       <SubmitButton

--- a/frontend/app/play/PlayingShell.tsx
+++ b/frontend/app/play/PlayingShell.tsx
@@ -155,6 +155,8 @@ export function PlayingShell({ state, onChange, onFinish }: Props) {
           defaultValue={(state.answers[q.id] as number | undefined) ?? q.min}
           unit={q.unit ?? ''}
           ticks={sliderTicks(q.min, q.max)}
+          minLabel={q.min_label}
+          maxLabel={q.max_label}
           onSubmit={(n) => advance(n)}
         />
       )}

--- a/frontend/app/types/admin-editor.ts
+++ b/frontend/app/types/admin-editor.ts
@@ -61,6 +61,8 @@ export type QuizEditorQuestionForm =
       step: number;
       tolerance: number;
       unit?: string | null;
+      minLabel?: string | null;
+      maxLabel?: string | null;
     });
 
 export interface QuizEditorFormValues {
@@ -125,6 +127,8 @@ export type AdminQuizApiQuestion =
       step: number;
       tolerance: number;
       unit?: string | null;
+      min_label?: string | null;
+      max_label?: string | null;
     };
 
 export interface AdminQuizApiDetails {
@@ -204,6 +208,8 @@ export type AdminQuizUpsertQuestionPayload =
       step: number;
       tolerance: number;
       unit?: string | null;
+      min_label?: string | null;
+      max_label?: string | null;
     };
 
 export interface AdminQuizUpsertPayload {

--- a/frontend/lib/admin-quiz/adapters.test.ts
+++ b/frontend/lib/admin-quiz/adapters.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
 import { it } from 'node:test';
 
-import type { QuizEditorFormValues } from '@/app/types/admin-editor';
+import type {
+  AdminQuizApiDetails,
+  QuizEditorFormValues,
+} from '@/app/types/admin-editor';
 
-import { toAdminQuizUpsertPayload } from './adapters';
+import { toAdminQuizUpsertPayload, toQuizEditorFormValues } from './adapters';
 
 it('maps choice image paths through form and payload', () => {
   const formValues: QuizEditorFormValues = {
@@ -32,4 +35,66 @@ it('maps choice image paths through form and payload', () => {
   const question = payload.questions[0];
   assert.ok('choices' in question, 'expected choices question');
   assert.strictEqual(question.choices[0].image, './media/asset_a');
+});
+
+it('carries slider extreme labels from the form into the payload', () => {
+  const formValues: QuizEditorFormValues = {
+    title: 'T',
+    description: null,
+    author: null,
+    tags: [],
+    showAnswerReview: true,
+    questions: [
+      {
+        type: 'slider',
+        text: 'Q',
+        timeS: null,
+        points: 1,
+        image: null,
+        hint: null,
+        correct: 5,
+        min: 1,
+        max: 10,
+        step: 1,
+        tolerance: 0,
+        unit: null,
+        minLabel: 'Zdecydowanie nie',
+        maxLabel: 'Zdecydowanie tak',
+      },
+    ],
+  };
+
+  const payload = toAdminQuizUpsertPayload(formValues);
+  const question = payload.questions[0];
+  assert.ok(question.type === 'slider', 'expected slider question');
+  assert.strictEqual(question.min_label, 'Zdecydowanie nie');
+  assert.strictEqual(question.max_label, 'Zdecydowanie tak');
+});
+
+it('reads slider extreme labels from the API into the form', () => {
+  const details: AdminQuizApiDetails = {
+    id: 'quiz_1',
+    title: 'T',
+    created_at: '2026-01-01T00:00:00Z',
+    questions: [
+      {
+        type: 'slider',
+        text: 'Q',
+        correct: 5,
+        min: 1,
+        max: 10,
+        step: 1,
+        tolerance: 0,
+        unit: null,
+        min_label: 'Nisko',
+        max_label: 'Wysoko',
+      },
+    ],
+  };
+
+  const values = toQuizEditorFormValues(details);
+  const question = values.questions[0];
+  assert.ok(question.type === 'slider', 'expected slider question');
+  assert.strictEqual(question.minLabel, 'Nisko');
+  assert.strictEqual(question.maxLabel, 'Wysoko');
 });

--- a/frontend/lib/admin-quiz/adapters.ts
+++ b/frontend/lib/admin-quiz/adapters.ts
@@ -105,6 +105,8 @@ function mapApiQuestionToForm(q: AdminQuizApiQuestion): QuizEditorQuestionForm {
         step: q.step,
         tolerance: q.tolerance,
         unit: q.unit ?? null,
+        minLabel: q.min_label ?? null,
+        maxLabel: q.max_label ?? null,
       };
     default: {
       const _exhaustive: never = q;
@@ -177,6 +179,8 @@ function coerceApiQuestionLoose(
       step: typeof raw.step === 'number' ? raw.step : 1,
       tolerance: typeof raw.tolerance === 'number' ? raw.tolerance : 0,
       unit: typeof raw.unit === 'string' ? raw.unit : null,
+      minLabel: typeof raw.min_label === 'string' ? raw.min_label : null,
+      maxLabel: typeof raw.max_label === 'string' ? raw.max_label : null,
     };
   }
 
@@ -342,6 +346,8 @@ function mapQuestionToPayload(
         step: q.step,
         tolerance: q.tolerance,
         unit: q.unit?.trim() ? q.unit.trim() : undefined,
+        min_label: q.minLabel?.trim() ? q.minLabel.trim() : undefined,
+        max_label: q.maxLabel?.trim() ? q.maxLabel.trim() : undefined,
       };
     default: {
       const _never: never = q;

--- a/frontend/lib/admin-quiz/defaults.ts
+++ b/frontend/lib/admin-quiz/defaults.ts
@@ -67,6 +67,8 @@ export function createQuestionForType(
         step: 1,
         tolerance: 0,
         unit: null,
+        minLabel: null,
+        maxLabel: null,
       };
     default: {
       const _exhaustive: never = type;

--- a/frontend/lib/admin-quiz/schemas.ts
+++ b/frontend/lib/admin-quiz/schemas.ts
@@ -150,6 +150,14 @@ const editorSliderSchema = questionCommonFormSchema
         }
         return v;
       }),
+    minLabel: z
+      .union([z.string(), z.literal(''), z.null()])
+      .optional()
+      .transform((v) => (v === undefined || v === null || v === '' ? null : v)),
+    maxLabel: z
+      .union([z.string(), z.literal(''), z.null()])
+      .optional()
+      .transform((v) => (v === undefined || v === null || v === '' ? null : v)),
   })
   .superRefine((q, ctx) => {
     if (q.min >= q.max) {
@@ -263,6 +271,8 @@ const adminQuizApiSliderSchema = z
     step: z.coerce.number(),
     tolerance: z.coerce.number(),
     unit: optionalTrimmedString,
+    min_label: optionalTrimmedString,
+    max_label: optionalTrimmedString,
   })
   .passthrough();
 
@@ -412,6 +422,26 @@ const upsertSliderSchema = z
     step: z.number().finite().positive().default(1),
     tolerance: z.number().finite().min(0).default(0),
     unit: z
+      .union([z.string(), z.literal(''), z.null()])
+      .optional()
+      .transform((v) => {
+        if (v === undefined || v === null || v === '') {
+          return undefined;
+        }
+        const t = v.trim();
+        return t === '' ? undefined : t;
+      }),
+    min_label: z
+      .union([z.string(), z.literal(''), z.null()])
+      .optional()
+      .transform((v) => {
+        if (v === undefined || v === null || v === '') {
+          return undefined;
+        }
+        const t = v.trim();
+        return t === '' ? undefined : t;
+      }),
+    max_label: z
       .union([z.string(), z.literal(''), z.null()])
       .optional()
       .transform((v) => {

--- a/frontend/lib/kqf/schemas.ts
+++ b/frontend/lib/kqf/schemas.ts
@@ -112,6 +112,8 @@ export const kqfSliderSchema = z
     step: z.number().default(1),
     tolerance: z.number().nonnegative().default(0),
     unit: nullableJsonString,
+    min_label: nullableJsonString,
+    max_label: nullableJsonString,
   })
   .superRefine((v, ctx) => {
     if (v.min >= v.max) {


### PR DESCRIPTION
## RDE-79 - Slider question UX

Closes RDE-79.

Makes slider questions clearer by letting the admin label the extremes (what the minimum and
maximum values mean), with a live preview and player rendering.

### What changed

- **Backend**: `KqfSlider` gains optional `min_label` / `max_label`. The KQF parser
  (`_SLIDER_FIELD_RE`, `_build_slider`) and serializer handle them, and they flow through the
  admin payload (`AdminQuizSliderPayload`) and adapters in both directions.
- **Frontend**: the slider form type, the editor / API / upsert Zod schemas, and the
  form<->API adapters all carry `minLabel` / `maxLabel`. The slider editor gets two label
  inputs and shows them in the range preview; the player (`SliderQuestion`) renders the labels
  under the slider extremes.

The min/max range, step, tolerance and unit were already configurable; this PR focuses on the
descriptive labels and preview.

### Acceptance criteria

- [x] Admin can set the slider min and max values (already supported, kept).
- [x] Admin can add labels for the extreme values.
- [x] The form clearly shows what the participant will see (label preview).
- [x] The slider question works correctly after saving (round-trip preserved).
- [x] The participant sees the labels next to the slider.

### Testing

- `backend/tests/test_kqf_roundtrip.py`: slider with extreme labels round-trips through
  serialize/parse.
- `frontend/lib/admin-quiz/adapters.test.ts`: labels survive form -> payload and API -> form.
- `frontend/app/components/quiz/questions/SliderQuestion.test.tsx`: labels render when present
  and the row is omitted when absent.
- `pnpm -C frontend validate` / `pnpm -C frontend test` and backend `pytest` pass.
