### PR TITLE
[RDE-82] feat(routing): redirect root path to /play

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-  redirect('/admin');
+  redirect('/play');
 }


### PR DESCRIPTION
## RDE-82 - Redirect `/` to `/play`

Closes RDE-82.

The default path `/` now redirects to `/play` (the participant entry point) instead of
`/admin`.

### What changed

- `frontend/app/page.tsx`: `redirect('/admin')` -> `redirect('/play')`.

### Acceptance criteria

- [x] Visiting `/` redirects to `/play`.

### Testing

- `pnpm -C frontend validate` passes (lint, prettier, type-check).
