### PR TITLE
[RDE-85] Allow admins to ban submitted participants from live leaderboard

### DIFF
--- a/backend/tests/test_play.py
+++ b/backend/tests/test_play.py
@@ -250,3 +250,26 @@ def test_leaderboard_excludes_participants_without_submission(
     client.post(f"/play/{pin}/join", json={"nickname": "JoinedOnly"})
     body = client.get(f"/play/{pin}/leaderboard").json()
     assert [e["nickname"] for e in body["entries"]] == ["Submitted"]
+
+
+def test_leaderboard_excludes_participant_blocked_after_submission(
+    client: TestClient, admin_token_header: dict[str, str]
+) -> None:
+    quiz_id = _create_quiz(client, admin_token_header)
+    pin = client.post(
+        f"/admin/quiz/{quiz_id}/activate", headers=admin_token_header
+    ).json()["pin"]
+    client.post(f"/play/{pin}/join", json={"nickname": "Ala"})
+    client.post(f"/play/{pin}/submit", json={"nickname": "Ala", "score": 10})
+    client.post(f"/play/{pin}/join", json={"nickname": "Bob"})
+    client.post(f"/play/{pin}/submit", json={"nickname": "Bob", "score": 5})
+
+    blocked = client.post(
+        f"/admin/quiz/{quiz_id}/session/block",
+        json={"nickname": "Ala"},
+        headers=admin_token_header,
+    )
+    assert blocked.status_code == 200
+
+    body = client.get(f"/play/{pin}/leaderboard").json()
+    assert [e["nickname"] for e in body["entries"]] == ["Bob"]

--- a/frontend/app/components/admin/dashboard/RunningQuizView.tsx
+++ b/frontend/app/components/admin/dashboard/RunningQuizView.tsx
@@ -27,6 +27,7 @@ import { SortableTh } from '@/app/components/common/SortableTh';
 import { useSortableColumns } from '@/hooks/useSortableColumns';
 import { formatAdminDate } from '@/lib/admin-date-time';
 import { APP_LOGO_URL } from '@/lib/branding';
+import { canAdminBlockParticipant } from '@/lib/sessions/blocking';
 import {
   activateQuiz,
   AdminFetchError,
@@ -543,7 +544,7 @@ export function RunningQuizView({
                       {formatScoreVsMax(p.score, snap?.max_score ?? 0)}
                     </td>
                     <td className={adminBlueHeadTableTdClass}>
-                      {!p.blocked && !p.has_submitted && (
+                      {canAdminBlockParticipant(p) && (
                         <button
                           type="button"
                           className={adminDangerOutlineButtonClass}

--- a/frontend/lib/sessions/blocking.test.ts
+++ b/frontend/lib/sessions/blocking.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { canAdminBlockParticipant } from './blocking';
+
+test('admin can block a participant who already submitted', () => {
+  assert.equal(
+    canAdminBlockParticipant({
+      blocked: false,
+      has_submitted: true,
+    }),
+    true,
+  );
+});
+
+test('admin cannot block a participant who is already blocked', () => {
+  assert.equal(
+    canAdminBlockParticipant({
+      blocked: true,
+      has_submitted: true,
+    }),
+    false,
+  );
+});

--- a/frontend/lib/sessions/blocking.ts
+++ b/frontend/lib/sessions/blocking.ts
@@ -1,0 +1,10 @@
+export interface BlockableParticipant {
+  blocked: boolean;
+  has_submitted: boolean;
+}
+
+export function canAdminBlockParticipant(
+  participant: BlockableParticipant,
+): boolean {
+  return !participant.blocked;
+}


### PR DESCRIPTION
## Summary
- allow admins to block participants even after they have submitted during a running quiz
- keep blocked participants excluded from the live leaderboard
- add regressions for frontend ban eligibility and backend leaderboard behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin blocking permission logic for quiz participants.
  * Ensured participants blocked after submission are properly excluded from leaderboard rankings.

* **Tests**
  * Added tests for participant blocking functionality and permission validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->